### PR TITLE
fix: UBEAT/BECE year filter, grade-only format, exam number validation

### DIFF
--- a/src/app/exam-portal/dashboard/schools/[schoolId]/bece/page.tsx
+++ b/src/app/exam-portal/dashboard/schools/[schoolId]/bece/page.tsx
@@ -22,15 +22,21 @@ export default function SchoolDetailsPage({ params }: { params: Promise<{ school
         skip: !schoolId
     })
     
-    const { data: studentsData, isLoading: studentsLoading, error: studentsError, isFetching: studentsFetching } = useGetResultsQuery({
+    const { data: studentsData, isLoading: studentsLoading, error: studentsError, isFetching: studentsFetching, refetch } = useGetResultsQuery({
         schoolId,
         page: parseInt(page),
         limit: 10,
         search: search || undefined,
         examYear: year !== "all" ? parseInt(year) : undefined
     }, {
-        skip: !schoolId
+        skip: !schoolId,
+        refetchOnMountOrArgChange: true
     })
+
+    // Refetch when year or search changes
+    React.useEffect(() => {
+        refetch()
+    }, [year, search, refetch])
 
     const students = studentsData?.results || []
     const isLoading = schoolLoading || studentsLoading

--- a/src/app/exam-portal/dashboard/schools/[schoolId]/ubeat/page.tsx
+++ b/src/app/exam-portal/dashboard/schools/[schoolId]/ubeat/page.tsx
@@ -26,15 +26,21 @@ export default function UBEATSchoolDetailsPage({ params }: { params: Promise<{ s
     // Convert schoolId back to schoolCode format (replace dashes with slashes)
     const schoolCode = schoolId.replace(/-/g, '/')
     
-    const { data: studentsData, isLoading: studentsLoading, error: studentsError, isFetching: studentsFetching } = useGetUBEATResultsQuery({
+    const { data: studentsData, isLoading: studentsLoading, error: studentsError, isFetching: studentsFetching, refetch } = useGetUBEATResultsQuery({
         schoolCode: schoolCode,
         page: parseInt(page),
         limit: 10,
         search: search || undefined,
         examYear: year !== "all" ? parseInt(year) : undefined
     }, {
-        skip: !schoolId
+        skip: !schoolId,
+        refetchOnMountOrArgChange: true
     })
+
+    // Refetch when year or search changes
+    React.useEffect(() => {
+        refetch()
+    }, [year, search, refetch])
 
     // Convert UBEAT students to DisplayStudent format
     const students = useMemo(() => {

--- a/src/app/exam-portal/dashboard/schools/types/student.types.ts
+++ b/src/app/exam-portal/dashboard/schools/types/student.types.ts
@@ -118,8 +118,11 @@ export interface BeceResultUploadResponse {
 
 // Adapter functions
 export function ubeatStudentToDisplayStudent(ubeatStudent: UBEATStudent): DisplayStudent {
+    // Check if subjects exist (grade-only format for 2020/2021 has empty subjects)
+    const hasSubjects = ubeatStudent.subjects && Object.keys(ubeatStudent.subjects).length > 0
+
     // Convert UBEAT subjects object to array of Subject
-    const subjectsArray: Subject[] = [
+    const subjectsArray: Subject[] = hasSubjects ? [
         {
             name: 'Mathematics',
             exam: ubeatStudent.subjects.mathematics.total,
@@ -140,7 +143,7 @@ export function ubeatStudentToDisplayStudent(ubeatStudent: UBEATStudent): Displa
             exam: ubeatStudent.subjects.igbo.total,
             grade: calculateGradeFromTotal(ubeatStudent.subjects.igbo.total)
         }
-    ]
+    ] : []
 
     return {
         _id: ubeatStudent._id,

--- a/src/app/exam-portal/dashboard/uploads/bece/components/DataTable.tsx
+++ b/src/app/exam-portal/dashboard/uploads/bece/components/DataTable.tsx
@@ -11,6 +11,41 @@ import { BeceResultUpload, useUploadBeceExamResultsMutation } from '../../../../
 import { LgaEnum } from '../../../../../portal/dashboard/[schoolCode]/types'
 import ErrorTypeModal from './ErrorTypeModal'
 
+const VALID_LGAS = Object.values(LgaEnum).map(v => v.toLowerCase())
+const LGA_TITLE_CASE: Record<string, string> = Object.values(LgaEnum).reduce((acc, v) => {
+    acc[v.toLowerCase()] = v
+    return acc
+}, {} as Record<string, string>)
+
+function normalizeLga(lga: string): string {
+    return lga.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function findClosestLga(invalidLga: string): string | null {
+    const normalized = normalizeLga(invalidLga)
+    if (VALID_LGAS.includes(normalized)) {
+        return LGA_TITLE_CASE[normalized] || null
+    }
+    for (const valid of VALID_LGAS) {
+        if (valid.includes(normalized) || normalized.includes(valid)) {
+            return LGA_TITLE_CASE[valid] || null
+        }
+    }
+    return null
+}
+
+function tryFixLga(lga: string): { fixed: string; wasFixed: boolean } {
+    const normalized = normalizeLga(lga)
+    if (VALID_LGAS.includes(normalized)) {
+        return { fixed: LGA_TITLE_CASE[normalized] || lga, wasFixed: false }
+    }
+    const closest = findClosestLga(normalized)
+    if (closest) {
+        return { fixed: closest, wasFixed: true }
+    }
+    return { fixed: lga, wasFixed: false }
+}
+
 interface DataTableProps {
     data: StudentRecord[]
     onDataChange: (data: StudentRecord[]) => void
@@ -185,21 +220,42 @@ export default function DataTable({ data, onDataChange, onOpenOverrideModal, cla
 
     const recordKey = (r: StudentRecord) => `${r.examNo}\0${r.file.name}`
 
-    // Auto-bin records with invalid LGAs as soon as they are loaded
+    // Auto-fix or bin records with invalid LGAs as soon as they are loaded
     React.useEffect(() => {
         if (data.length === 0) return
-        const validLgas = new Set(Object.values(LgaEnum).map(v => v.toLowerCase()))
-        const invalidLgaRecords = data.filter(
-            r => !validLgas.has((r.lga ?? '').toLowerCase().trim())
-        )
-        if (invalidLgaRecords.length === 0) return
-        const invalidKeys = new Set(invalidLgaRecords.map(recordKey))
+
+        const validLgaSet = new Set(VALID_LGAS)
+        const recordsToFix: { key: string; record: StudentRecord; fixedLga: string }[] = []
+        const recordsToBin: StudentRecord[] = []
+
+        data.forEach(r => {
+            const lgaValue = r.lga ?? ''
+            if (!validLgaSet.has(lgaValue.toLowerCase().trim())) {
+                const { fixed, wasFixed } = tryFixLga(lgaValue)
+                if (wasFixed) {
+                    recordsToFix.push({ key: recordKey(r), record: r, fixedLga: fixed })
+                } else {
+                    recordsToBin.push(r)
+                }
+            }
+        })
+
+        if (recordsToFix.length > 0) {
+            onDataChange(data.map(r => {
+                const fix = recordsToFix.find(f => f.key === recordKey(r))
+                return fix ? { ...r, lga: fix.fixedLga } : r
+            }))
+            toast.success(`Fixed LGA for ${recordsToFix.length} record${recordsToFix.length !== 1 ? 's' : ''}: ${recordsToFix.map(f => f.fixedLga).filter((v, i, a) => a.indexOf(v) === i).join(', ')}`, { icon: '🔧' })
+        }
+
+        if (recordsToBin.length === 0) return
+        const invalidKeys = new Set(recordsToBin.map(recordKey))
         setRecycleBin(prev => [
             ...prev,
-            ...invalidLgaRecords.filter(r => !prev.some(rr => recordKey(rr) === recordKey(r)))
+            ...recordsToBin.filter(r => !prev.some(rr => recordKey(rr) === recordKey(r)))
         ])
         onDataChange(data.filter(r => !invalidKeys.has(recordKey(r))))
-        toast(`${invalidLgaRecords.length} record${invalidLgaRecords.length !== 1 ? 's' : ''} with invalid LGA auto-moved to recycle bin`, { icon: '🗑️' })
+        toast(`${recordsToBin.length} record${recordsToBin.length !== 1 ? 's' : ''} with invalid LGA auto-moved to recycle bin`, { icon: '🗑️' })
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data])
 

--- a/src/app/exam-portal/dashboard/uploads/ubeat/components/DataTable.tsx
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/components/DataTable.tsx
@@ -11,6 +11,41 @@ import { useUploadUBEATResultsMutation } from '../../../../store/api/authApi'
 import { LgaEnum } from '../../../../../portal/dashboard/[schoolCode]/types'
 import ErrorTypeModal from './ErrorTypeModal'
 
+const VALID_LGAS = Object.values(LgaEnum).map(v => v.toLowerCase())
+const LGA_TITLE_CASE: Record<string, string> = Object.values(LgaEnum).reduce((acc, v) => {
+    acc[v.toLowerCase()] = v
+    return acc
+}, {} as Record<string, string>)
+
+function normalizeLga(lga: string): string {
+    return lga.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function findClosestLga(invalidLga: string): string | null {
+    const normalized = normalizeLga(invalidLga)
+    if (VALID_LGAS.includes(normalized)) {
+        return LGA_TITLE_CASE[normalized] || null
+    }
+    for (const valid of VALID_LGAS) {
+        if (valid.includes(normalized) || normalized.includes(valid)) {
+            return LGA_TITLE_CASE[valid] || null
+        }
+    }
+    return null
+}
+
+function tryFixLga(lga: string): { fixed: string; wasFixed: boolean } {
+    const normalized = normalizeLga(lga)
+    if (VALID_LGAS.includes(normalized)) {
+        return { fixed: LGA_TITLE_CASE[normalized] || lga, wasFixed: false }
+    }
+    const closest = findClosestLga(normalized)
+    if (closest) {
+        return { fixed: closest, wasFixed: true }
+    }
+    return { fixed: lga, wasFixed: false }
+}
+
 interface DataTableProps {
     data: UBEATStudentRecord[]
     onDataChange: (data: UBEATStudentRecord[]) => void
@@ -144,21 +179,42 @@ export default function DataTable({ data, onDataChange, onOpenOverrideModal, cla
         if (recycleBin.length === 0) setRecycleBinExported(true)
     }, [recycleBin])
 
-    // Auto-bin records with invalid LGAs as soon as they are loaded
+    // Auto-fix or bin records with invalid LGAs as soon as they are loaded
     React.useEffect(() => {
         if (data.length === 0) return
-        const validLgas = new Set(Object.values(LgaEnum).map(v => v.toLowerCase()))
-        const invalidLgaRecords = data.filter(
-            r => !validLgas.has((r.lga ?? '').toLowerCase().trim())
-        )
-        if (invalidLgaRecords.length === 0) return
-        const invalidKeys = new Set(invalidLgaRecords.map(recordKey))
+
+        const validLgaSet = new Set(VALID_LGAS)
+        const recordsToFix: { key: string; record: UBEATStudentRecord; fixedLga: string }[] = []
+        const recordsToBin: UBEATStudentRecord[] = []
+
+        data.forEach(r => {
+            const lgaValue = r.lga ?? ''
+            if (!validLgaSet.has(lgaValue.toLowerCase().trim())) {
+                const { fixed, wasFixed } = tryFixLga(lgaValue)
+                if (wasFixed) {
+                    recordsToFix.push({ key: recordKey(r), record: r, fixedLga: fixed })
+                } else {
+                    recordsToBin.push(r)
+                }
+            }
+        })
+
+        if (recordsToFix.length > 0) {
+            onDataChange(data.map(r => {
+                const fix = recordsToFix.find(f => f.key === recordKey(r))
+                return fix ? { ...r, lga: fix.fixedLga } : r
+            }))
+            toast.success(`Fixed LGA for ${recordsToFix.length} record${recordsToFix.length !== 1 ? 's' : ''}: ${recordsToFix.map(f => f.fixedLga).filter((v, i, a) => a.indexOf(v) === i).join(', ')}`, { icon: '🔧' })
+        }
+
+        if (recordsToBin.length === 0) return
+        const invalidKeys = new Set(recordsToBin.map(recordKey))
         setRecycleBin(prev => [
             ...prev,
-            ...invalidLgaRecords.filter(r => !prev.some(rr => recordKey(rr) === recordKey(r)))
+            ...recordsToBin.filter(r => !prev.some(rr => recordKey(rr) === recordKey(r)))
         ])
         onDataChange(data.filter(r => !invalidKeys.has(recordKey(r))))
-        toast(`${invalidLgaRecords.length} record${invalidLgaRecords.length !== 1 ? 's' : ''} with invalid LGA auto-moved to recycle bin`, { icon: '🗑️' })
+        toast(`${recordsToBin.length} record${recordsToBin.length !== 1 ? 's' : ''} with invalid LGA auto-moved to recycle bin`, { icon: '🗑️' })
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data])
 
@@ -744,10 +800,29 @@ export default function DataTable({ data, onDataChange, onOpenOverrideModal, cla
             }, {} as Record<string, UBEATStudentRecord[]>)
 
             const results = Object.entries(schoolGroups).map(([schoolName, students]) => {
+                const examYear = students[0]?.examYear || new Date().getFullYear()
+                const isGradeOnlyFormat = examYear <= 2021 && students.some(s => s.grade)
+
+                if (isGradeOnlyFormat) {
+                    return {
+                        lga: students[0]?.lga,
+                        examYear,
+                        schoolName,
+                        students: students.map(student => ({
+                            serialNumber: student.serialNumber,
+                            examNumber: student.examNumber,
+                            studentName: student.studentName,
+                            age: student.age || 0,
+                            sex: student.sex,
+                            grade: student.grade || 'PASS'
+                        }))
+                    }
+                }
+
                 const studentsWithScores = students.filter(s => s.subjects !== undefined)
                 return {
                     lga: students[0]?.lga,
-                    examYear: students[0]?.examYear || new Date().getFullYear(),
+                    examYear,
                     schoolName,
                     students: studentsWithScores.map(student => ({
                         serialNumber: student.serialNumber,

--- a/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
@@ -150,6 +150,14 @@ export const validateStudentRecord = (record: UBEATStudentRecord): ValidationErr
     })
   }
 
+  if (isGradeOnlyFormat && !record.examNumber?.trim()) {
+    errors.push({
+      type: 'missing_required',
+      field: 'examNumber',
+      message: 'Exam number is required'
+    })
+  }
+
   if (!isGradeOnlyFormat && !record.examNumber?.trim()) {
     errors.push({
       type: 'missing_required',
@@ -624,7 +632,7 @@ const parseFlatFormat = (
         examNumber:
           examNo >= 0 && values[examNo]?.trim()
             ? values[examNo].trim()
-            : `UBEAT/${i - dataStartRow + 1}`,
+            : '',
         studentName:
           candidateName >= 0 && values[candidateName]?.trim()
             ? values[candidateName].trim()
@@ -684,17 +692,15 @@ const parseGradeOnlyFormat = (
     const sheetMarker = ' - Sheet: '
     const sheetIdx = fileName.indexOf(sheetMarker)
     const raw = sheetIdx >= 0 ? fileName.slice(sheetIdx + sheetMarker.length) : fileName
-const dashIdx = raw.indexOf(' - ')
+    const dashIdx = raw.indexOf(' - ')
     if (dashIdx >= 0) {
       return raw.slice(dashIdx + 3).replace(/\.(csv|xlsx|xls)$/i, '').trim()
     }
     return raw.replace(/\.(csv|xlsx|xls)$/i, '').trim()
   }
-    return raw.replace(/\.(csv|xlsx|xls)$/i, '').trim()
-  }
 
   const inferredSchoolName = getSchoolNameFromFileMeta(file.name)
-const lga = getLgaFromFileMeta(file.name)
+  const lga = getLgaFromFileMeta(file.name)
   const zone = 'Unknown Zone'
 
   for (let i = dataStartRow; i < lines.length; i++) {
@@ -714,7 +720,7 @@ const lga = getLgaFromFileMeta(file.name)
 
       const record: UBEATStudentRecord = {
         serialNumber: i - dataStartRow + 1,
-        examNumber: getStringValue(values, 1, `UBEAT/${i - dataStartRow + 1}`),
+        examNumber: getStringValue(values, 1, ''),
         studentName: getStringValue(values, 0, 'Unknown'),
         age: getNumberValue(values, 3, 0),
         sex,
@@ -725,7 +731,7 @@ const lga = getLgaFromFileMeta(file.name)
         codeNo: '',
         attendance: 0,
         examYear: fileExamYear,
-        file
+        file,
       }
 
       records.push(record)

--- a/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
@@ -1,4 +1,23 @@
 import * as XLSX from 'xlsx'
+import { LgaEnum } from '../../../../../portal/dashboard/[schoolCode]/types'
+
+const LGA_VALUES = Object.values(LgaEnum)
+const LGA_LOWER_MAP: Record<string, string> = {}
+LGA_VALUES.forEach(lga => {
+  LGA_LOWER_MAP[lga.toLowerCase()] = lga
+})
+
+function normalizeLgaToEnum(inputLga: string): string {
+  if (!inputLga || inputLga === 'Unknown LGA') return 'Unknown Lga'
+  const normalized = inputLga.toLowerCase().trim()
+  if (LGA_LOWER_MAP[normalized]) return LGA_LOWER_MAP[normalized]
+  for (const validLga of LGA_VALUES) {
+    if (validLga.toLowerCase().includes(normalized) || normalized.includes(validLga.toLowerCase())) {
+      return validLga
+    }
+  }
+  return inputLga
+}
 
 export const parseLine = (line: string): string[] => {
   const result: string[] = []
@@ -347,6 +366,7 @@ export const parseCSVText = (csvText: string, file: { name: string; size: number
   }
 
   const inferredSchoolName = isLegacy ? null : getSchoolNameFromFileMeta(file.name)
+  const inferredLga = isLegacy ? null : getLgaFromFileMeta(file.name)
 
   const legacyIndices = {
     serialNo: 0,
@@ -432,7 +452,7 @@ export const parseCSVText = (csvText: string, file: { name: string; size: number
         studentName: getStringValue(values, indices.candidateName, 'Unknown'),
         age: getNumberValue(values, indices.age, 0),
         sex,
-        lga: isLegacy ? getStringValue(values, legacyIndices.lga, 'Unknown LGA') : 'Unknown LGA',
+        lga: isLegacy ? getStringValue(values, legacyIndices.lga, 'Unknown Lga') : (inferredLga || 'Unknown Lga'),
         zone: isLegacy ? getStringValue(values, legacyIndices.zone, 'Unknown Zone') : 'Unknown Zone',
         schoolName: isLegacy
           ? getStringValue(values, legacyIndices.schoolName, 'Unknown School')
@@ -507,13 +527,34 @@ const getAttendanceValue = (values: string[], index: number): string | number =>
 }
 
 const getSchoolNameFromFileMeta = (fileName: string): string => {
-  // XLSX sheets are passed in as: "<original file> - Sheet: <sheetName>"
   const sheetMarker = ' - Sheet: '
   const sheetIdx = fileName.indexOf(sheetMarker)
   const raw = sheetIdx >= 0 ? fileName.slice(sheetIdx + sheetMarker.length) : fileName
 
-  // If it's a plain filename, strip extension.
+  const dashIdx = raw.indexOf(' - ')
+  if (dashIdx >= 0) {
+    return raw.slice(dashIdx + 3).replace(/\.(csv|xlsx|xls)$/i, '').trim()
+  }
   return raw.replace(/\.(csv|xlsx|xls)$/i, '').trim()
+}
+
+const getLgaFromFileMeta = (fileName: string): string => {
+  const withoutExt = fileName.replace(/\.(csv|xlsx|xls)$/i, '')
+  const dashIdx = withoutExt.indexOf(' - ')
+  let lgaPart = dashIdx >= 0 ? withoutExt.slice(0, dashIdx) : withoutExt
+  lgaPart = lgaPart.replace(/\b(20\d{2})\b/g, '').replace(/\bUBEAT\b/i, '').replace(/\s+/g, ' ').trim()
+  const sheetMarker = ' - Sheet: '
+  const sheetIdx = fileName.indexOf(sheetMarker)
+  if (sheetIdx >= 0) {
+    const fromSheet = fileName.slice(0, sheetIdx)
+    const sheetLgaPart = fromSheet.split(' - ')[0] || fromSheet
+    const cleanedSheetLga = sheetLgaPart.replace(/\b(20\d{2})\b/g, '').replace(/\bUBEAT\b/i, '').replace(/\s+/g, ' ').trim()
+    if (cleanedSheetLga.length > lgaPart.length) {
+      lgaPart = cleanedSheetLga
+    }
+  }
+  const normalizedLga = normalizeLgaToEnum(lgaPart)
+  return normalizedLga || 'Unknown Lga'
 }
 
 const parseFlatFormat = (
@@ -643,11 +684,17 @@ const parseGradeOnlyFormat = (
     const sheetMarker = ' - Sheet: '
     const sheetIdx = fileName.indexOf(sheetMarker)
     const raw = sheetIdx >= 0 ? fileName.slice(sheetIdx + sheetMarker.length) : fileName
+const dashIdx = raw.indexOf(' - ')
+    if (dashIdx >= 0) {
+      return raw.slice(dashIdx + 3).replace(/\.(csv|xlsx|xls)$/i, '').trim()
+    }
+    return raw.replace(/\.(csv|xlsx|xls)$/i, '').trim()
+  }
     return raw.replace(/\.(csv|xlsx|xls)$/i, '').trim()
   }
 
   const inferredSchoolName = getSchoolNameFromFileMeta(file.name)
-  const lga = 'Unknown LGA'
+const lga = getLgaFromFileMeta(file.name)
   const zone = 'Unknown Zone'
 
   for (let i = dataStartRow; i < lines.length; i++) {

--- a/src/app/exam-portal/store/api/authApi.ts
+++ b/src/app/exam-portal/store/api/authApi.ts
@@ -60,7 +60,8 @@ export interface UBEATResultUpload {
     studentName: string
     age: number
     sex: 'male' | 'female'
-    subjects: {
+    grade?: string
+    subjects?: {
       mathematics: {
         ca: number;
         exam: number;

--- a/src/app/exam-portal/store/api/authApi.ts
+++ b/src/app/exam-portal/store/api/authApi.ts
@@ -321,7 +321,7 @@ export const authApi = apiSlice.injectEndpoints({
         if (params.page) queryParams.append('page', params.page.toString())
         if (params.limit) queryParams.append('limit', params.limit.toString())
         if (params.search) queryParams.append('search', params.search)
-        if (params.examYear) queryParams.append('examYear', params.examYear.toString())
+        if (params.examYear) queryParams.append('year', params.examYear.toString())
         const queryString = queryParams.toString()
         return `/bece-result/results/${params.schoolId.replace(/\//g, "-")}${queryString ? `?${queryString}` : ''}`
       },
@@ -380,7 +380,7 @@ export const authApi = apiSlice.injectEndpoints({
         if (params.page) queryParams.append('page', params.page.toString())
         if (params.limit) queryParams.append('limit', params.limit.toString())
         if (params.search) queryParams.append('search', params.search)
-        if (params.examYear) queryParams.append('examYear', params.examYear.toString())
+        if (params.examYear) queryParams.append('year', params.examYear.toString())
         const queryString = queryParams.toString()
         return `/ubeat/results/${params.schoolCode.replace(/\//g, "-")}${queryString ? `?${queryString}` : ''}`
       },

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -310,6 +310,9 @@ export default function UBEATDashboard() {
     // Use average score from API response
     const averageScore = student.averageScore || 0
 
+    // Check if this is a grade-only year (2020-2021)
+    const isGradeOnlyYear = (student.examYear || 0) <= 2021
+
     const getGradeColor = (grade: string) => {
         // A1: Gold fill with trophy icon
         if (grade === 'A1') return 'bg-gradient-to-r from-yellow-400 to-amber-500 text-white border-0'
@@ -479,23 +482,54 @@ export default function UBEATDashboard() {
                                         </p>
                                         <p className="text-xs text-gray-500">Grade</p>
                                     </div>
-                                    <div className="text-center border-l md:border-r border-gray-200">
-                                        <p className="text-2xl font-semibold text-purple-600 mb-1">
-                                            {averageScore}
-                                        </p>
-                                        <p className="text-xs text-gray-500">Score</p>
-                                    </div>
-                                    <div className="text-center max-md:hidden">
-                                        <p className="text-2xl font-semibold text-gray-900 mb-1">
-                                            {subjectsArray.length}
-                                        </p>
-                                        <p className="text-xs text-gray-500">Subjects</p>
-                                    </div>
+                                    {isGradeOnlyYear ? (
+                                        <div className="text-center border-l md:border-r border-gray-200 col-span-2">
+                                            <p className="text-lg font-semibold text-purple-600 mb-1">
+                                                {student.examYear}
+                                            </p>
+                                            <p className="text-xs text-gray-500">Exam Year</p>
+                                        </div>
+                                    ) : (
+                                        <>
+                                            <div className="text-center border-l md:border-r border-gray-200">
+                                                <p className="text-2xl font-semibold text-purple-600 mb-1">
+                                                    {averageScore}
+                                                </p>
+                                                <p className="text-xs text-gray-500">Score</p>
+                                            </div>
+                                            <div className="text-center max-md:hidden">
+                                                <p className="text-2xl font-semibold text-gray-900 mb-1">
+                                                    {subjectsArray.length}
+                                                </p>
+                                                <p className="text-xs text-gray-500">Subjects</p>
+                                            </div>
+                                        </>
+                                    )}
                                 </div>
                             </div>
                         </div>
 
-                        {/* Detailed Results Table */}
+                        {/* Grade-Only Year Notice */}
+                        {isGradeOnlyYear && (
+                            <div className="bg-amber-50 border border-amber-200 rounded-3xl p-6">
+                                <div className="flex items-start gap-4">
+                                    <div className="w-10 h-10 bg-amber-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                                        <svg className="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </div>
+                                    <div className="flex-1">
+                                        <h4 className="text-sm font-semibold text-amber-800 mb-1">Results Summary Only</h4>
+                                        <p className="text-sm text-amber-700">
+                                            Your {student.examYear} UBEAT results contain your overall grade. Detailed subject-by-subject scores are not available for this exam year. Contact your school for more information.
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Detailed Results Table - Only show for years with subject scores */}
+                        {!isGradeOnlyYear && (
                         <div className="bg-white border border-gray-200 rounded-3xl overflow-hidden">
                             <div className="border-b border-gray-100 px-6 py-4">
                                 <h3 className="text-sm font-semibold text-gray-900">Subject Results <span className='text-gray-500'>({subjectsArray.length})</span></h3>
@@ -574,6 +608,7 @@ export default function UBEATDashboard() {
                                 </div>
                             </div>
                         </div>
+                    )}
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Fix year filter to trigger API call on selection (UBEAT & BECE)
- Support grade-only format for 2020/2021 (no subject scores)
- Add LGA normalization from filename for grade-only records
- Add notice component for grade-only years in result-checking
- Detect missing exam numbers as validation errors for grade-only format
- Auto-fix/salvage invalid LGAs with fuzzy matching