### PR TITLE
fix: resolve bin glitch - unique record keys

### DIFF
--- a/src/app/exam-portal/dashboard/uploads/ubeat/components/DataTable.tsx
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/components/DataTable.tsx
@@ -72,7 +72,7 @@ function parseSearchQuery(raw: string): { mode: SearchMode; field: SearchField; 
 }
 
 function recordKey(r: UBEATStudentRecord) {
-    return `${r.examNumber}\0${r.file.name}`
+    return `${r.examNumber || 'MISSING'}\0${r.serialNumber}\0${r.file.name}`
 }
 
 function exportRecycleBinCsv(records: UBEATStudentRecord[]) {

--- a/src/app/exam-portal/dashboard/uploads/ubeat/components/ErrorTypeModal.tsx
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/components/ErrorTypeModal.tsx
@@ -25,7 +25,7 @@ interface ErrorTypeModalProps {
   validateRecord: (record: any) => ValidationError[]
 }
 
-const recordKey = (r: any) => `${r.examNumber}\0${r.file.name}`
+const recordKey = (r: any) => `${r.examNumber || 'MISSING'}\0${r.serialNumber}\0${r.file.name}`
 
 const errorTypeConfig: Record<string, { color: string; bgColor: string; label: string }> = {
   name_special_chars: { color: 'text-yellow-700', bgColor: 'bg-yellow-50', label: 'Name with Invalid Characters' },


### PR DESCRIPTION
## Summary
- Fix recordKey to include serialNumber for uniqueness
- Previously used only examNumber + file.name causing duplicate keys when examNumber was empty
- Now uses: `${examNumber || 'MISSING'}\0${serialNumber}\0${file.name}`

## Impact
- Binning now works correctly - all binned items appear in bin
- Applies to both UBEAT and BECE upload tables