### PR TITLE
fix: accept variations in exam number column header for grade-only format

### DIFF
--- a/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
+++ b/src/app/exam-portal/dashboard/uploads/ubeat/utils/csvParser.ts
@@ -377,7 +377,9 @@ export const parseCSVText = (csvText: string, file: { name: string; size: number
     row0[0]?.toLowerCase().includes('name')
   ) && (
     row0[1]?.toLowerCase().includes('exam number') ||
-    row0[1]?.toLowerCase().includes('exam no')
+    row0[1]?.toLowerCase().includes('exam no') ||
+    row0[1]?.toLowerCase().includes('candidate number') ||
+    row0[1]?.toLowerCase().includes('number')
   ) && (
     row0[2]?.toLowerCase().includes('sex')
   ) && (
@@ -392,7 +394,9 @@ export const parseCSVText = (csvText: string, file: { name: string; size: number
     row0[0]?.toLowerCase().includes('name')
   ) && (
     row0[1]?.toLowerCase().includes('exam number') ||
-    row0[1]?.toLowerCase().includes('exam no')
+    row0[1]?.toLowerCase().includes('exam no') ||
+    row0[1]?.toLowerCase().includes('candidate number') ||
+    row0[1]?.toLowerCase().includes('number')
   ) && (
     row0[2]?.toLowerCase().includes('age')
   ) && (


### PR DESCRIPTION
## Summary
- Accept 'candidate number' and 'number' as valid exam number column header variations
- Fixes parsing of CSV files with typos like "CADIDATE NUMBER" instead of "CANDIDATE EXAM NUMBER"

## Changes
- Updated grade-only format detection to check for additional keywords