### PR TITLE
feat: add year selection + details check banner to result checking

### DIFF
--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -9,7 +9,8 @@ import animationData from '../../assets/students.json'
 import Image from 'next/image'
 import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
-import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, useFindMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
+import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, useFindBECEMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
@@ -177,6 +178,7 @@ export default function StudentLoginPage() {
 
     const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
     const [isFindingMatches, setIsFindingMatches] = useState(false)
+    const [confirmMatch, setConfirmMatch] = useState<MultiMatchResult | null>(null)
 
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
@@ -208,7 +210,7 @@ export default function StudentLoginPage() {
     const [getBECEResult, { isLoading, isFetching, isSuccess }] = useLazyGetBECEResultQuery()
     const [findBECEResult, { isLoading: isFindingResult }] = useFindBECEResultMutation()
     const [createBECEPayment, { isLoading: isCreatingPayment }] = useCreateBECEPaymentMutation()
-    const [findMultipleMatches] = useFindMultipleMatchesMutation()
+    const [findBECEMultipleMatches] = useFindBECEMultipleMatchesMutation()
     const isProcessingPayment = isFindingResult || isCreatingPayment
 
     const { data: schoolNames, isLoading: isLoadingSchoolNames, isFetching: isFetchingSchools } = useGetSchoolNamesQuery(
@@ -260,7 +262,7 @@ export default function StudentLoginPage() {
         try {
             setIsFindingMatches(true)
             toast.loading("Checking for matches...", { id: "finding-matches", duration: Infinity })
-            const matches = await findMultipleMatches({ examNumber: rawExamNo, year: parseInt(year) }).unwrap()
+            const matches = await findBECEMultipleMatches({ examNumber: rawExamNo, year: parseInt(year) }).unwrap()
 
             if (matches.length === 0) {
                 setError("No results found for this exam number and year.")
@@ -357,7 +359,7 @@ export default function StudentLoginPage() {
     const handleMultiMatchSelect = async (match: MultiMatchResult) => {
         setSelectedStudentId(match._id)
         setError('')
-        await proceedWithResult({ _id: match._id, examNo: examNo, year })
+        setConfirmMatch(match)
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -630,12 +632,12 @@ export default function StudentLoginPage() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.studentName)
+                                                                : getInitials(match.name)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.studentName.toLowerCase()}
+                                                                {match.name.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1062,6 +1064,20 @@ export default function StudentLoginPage() {
                                 <strong>📝 Note:</strong> Use your official BECE exam number from your school.
                             </p>
                         </div>
+                    )}
+
+                    {confirmMatch && (
+                        <DetailsCheckBanner
+                            context="retrieval"
+                            examNo={confirmMatch.examNo}
+                            studentName={confirmMatch.name}
+                            school={confirmMatch.school?.schoolName}
+                            onDismiss={() => {
+                                const match = confirmMatch
+                                setConfirmMatch(null)
+                                proceedWithResult({ _id: match._id, examNo: examNo, year })
+                            }}
+                        />
                     )}
 
                     <div className="mt-6 text-center">

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -754,7 +754,7 @@ export default function StudentLoginPage() {
                                                 id="examNo"
                                                 value={examNo}
                                                 onChange={e => { setExamNo(e.target.value.toLowerCase()); setError('') }}
-                                                placeholder="e.g., ok/977/2025/001"
+                                                placeholder="XX/XXX/XXX"
                                                 className={`block w-full pl-10 pr-3 py-3 border rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent hover:border-green-400 transition-all duration-200 uppercase ${error
                                                     ? 'border-red-300 bg-red-50'
                                                     : debouncedExamNo && !canProceed && debouncedExamNo.length > 0

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -215,7 +215,7 @@ export default function StudentLoginPage() {
         { skip: !altFormData.lga },
     )
 
-    const { data: availableYearsData } = useGetAvailableYearsQuery()
+    const { data: availableYearsData } = useGetAvailableYearsQuery({ examType: 'bece' })
     const availableYearOptions = useMemo(() => {
         return (availableYearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) }))
     }, [availableYearsData])

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -30,6 +30,7 @@ const IMO_STATE_LGAS = Object.values(LgaEnum);
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface RecentAccount {
+    _id?: string
     examNo: string
     studentName: string
     school: string
@@ -309,6 +310,7 @@ export default function StudentLoginPage() {
             }
 
             syncRecentAccount({
+                _id,
                 examNo: rawExamNo,
                 studentName: result.name,
                 school: result.school ?? '',
@@ -319,6 +321,7 @@ export default function StudentLoginPage() {
             await Promise.all([
                 SessionStore.set('student_exam_no', rawExamNo),
                 SessionStore.set('student_exam_year', yearVal),
+                SessionStore.set('student_exam_id', _id),
                 SessionStore.set('selected_exam_type', 'bece'),
             ])
 
@@ -367,13 +370,16 @@ export default function StudentLoginPage() {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getBECEResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
+            const result = selectedAccount._id
+                ? await getBECEResult({ _id: selectedAccount._id }).unwrap()
+                : await getBECEResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
             if (!result?.examNo || !result?.name) {
                 setError("Couldn't load results for this account.")
                 return
             }
 
             syncRecentAccount({
+                _id: selectedAccount._id,
                 examNo: selectedAccount.examNo,
                 studentName: result.name,
                 school: result.school ?? '',
@@ -385,6 +391,7 @@ export default function StudentLoginPage() {
             await Promise.all([
                 SessionStore.set('student_exam_no', selectedAccount.examNo),
                 SessionStore.set('student_exam_year', selectedAccount.year),
+                ...(selectedAccount._id ? [SessionStore.set('student_exam_id', selectedAccount._id)] : []),
                 SessionStore.set('selected_exam_type', 'bece'),
             ])
             toast.success(`Welcome back, ${result.name}! 🎉`)

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -9,7 +9,7 @@ import animationData from '../../assets/students.json'
 import Image from 'next/image'
 import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
-import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, type FindResultMatch } from '../../store/api/studentApi'
+import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, type FindResultMatch } from '../../store/api/studentApi'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
@@ -33,6 +33,7 @@ interface RecentAccount {
     examNo: string
     studentName: string
     school: string
+    year: string
     lastAccessed: number // Unix ms timestamp
 }
 
@@ -98,7 +99,7 @@ function RecentAccountCard({
     isLoading,
 }: {
     account: RecentAccount
-    onSelect: (examNo: string) => void
+    onSelect: (account: RecentAccount) => void
     onRemove: (examNo: string) => void
     isLoading: boolean
 }) {
@@ -107,7 +108,7 @@ function RecentAccountCard({
             variants={itemVariants}
             layout
             className={`group relative flex items-center gap-3 px-3 py-2.5 rounded-xl border border-gray-100 bg-gray-50 hover:bg-green-50 hover:border-green-200 transition-all duration-150 cursor-pointer ${isLoading ? 'opacity-50 cursor-not-allowed grayscale-50' : ''}`}
-            onClick={!isLoading ? () => onSelect(account.examNo) : () => { }}
+            onClick={!isLoading ? () => onSelect(account) : () => { }}
         >
             {/* Avatar */}
             <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
@@ -122,6 +123,7 @@ function RecentAccountCard({
                 <p className="text-xs text-gray-400 truncate font-mono uppercase">
                     {account.examNo}
                 </p>
+                <p className="text-[10px] text-gray-400">{account.year}</p>
             </div>
 
             {/* Time + arrow */}
@@ -148,6 +150,7 @@ export default function StudentLoginPage() {
     const searchParams = useSearchParams()
 
     const [examNo, setExamNo] = useState('')
+    const [year, setYear] = useState('')
     const [error, setError] = useState('')
     const [showAllAccounts, setShowAllAccounts] = useState(false)
 
@@ -208,11 +211,16 @@ export default function StudentLoginPage() {
         { skip: !altFormData.lga },
     )
 
+    const { data: availableYearsData } = useGetAvailableYearsQuery()
+    const availableYearOptions = useMemo(() => {
+        return (availableYearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) }))
+    }, [availableYearsData])
+
     const schoolNamesList = useMemo(() => schoolNames ?? [], [schoolNames])
     const lgaOptions = useMemo(() => IMO_STATE_LGAS.map(lga => ({ value: lga, label: lga })), [])
 
     const debouncedExamNo = useDebounce(examNo, 500)
-    const canProceed = debouncedExamNo.length >= 6 && isValidExamNo(debouncedExamNo)
+    const canProceed = debouncedExamNo.length >= 6 && isValidExamNo(debouncedExamNo) && year.trim().length === 4
 
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
     const isMaintenanceMode = !API_BASE_URL
@@ -237,13 +245,16 @@ export default function StudentLoginPage() {
             setError("Invalid format. Try: ok/977/2025/001")
             return
         }
+        if (!year.trim() || year.trim().length !== 4) {
+            setError('Please enter a valid exam year'); return
+        }
 
         try {
             toast.loading("Loading your results...", {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getBECEResult(examNo).unwrap()
+            const result = await getBECEResult({ examNo, year }).unwrap()
 
             if (!result?.examNo || !result?.name) {
                 setError("Couldn't load your results. Please try again.")
@@ -254,11 +265,13 @@ export default function StudentLoginPage() {
                 examNo: examNo,
                 studentName: result.name,
                 school: result.school ?? '',
+                year,
                 lastAccessed: Date.now(),
             })
 
             await Promise.all([
                 SessionStore.set('student_exam_no', examNo),
+                SessionStore.set('student_exam_year', year),
                 SessionStore.set('selected_exam_type', 'bece'),
             ])
 
@@ -291,8 +304,9 @@ export default function StudentLoginPage() {
         }
     }
 
-    const handleSelectRecent = async (selectedExamNo: string) => {
-        setExamNo(selectedExamNo)
+    const handleSelectRecent = async (selectedAccount: RecentAccount) => {
+        setExamNo(selectedAccount.examNo)
+        setYear(selectedAccount.year)
         setError('')
 
         try {
@@ -300,22 +314,24 @@ export default function StudentLoginPage() {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getBECEResult(selectedExamNo).unwrap()
+            const result = await getBECEResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
             if (!result?.examNo || !result?.name) {
                 setError("Couldn't load results for this account.")
                 return
             }
 
             syncRecentAccount({
-                examNo: selectedExamNo,
+                examNo: selectedAccount.examNo,
                 studentName: result.name,
                 school: result.school ?? '',
+                year: selectedAccount.year,
                 lastAccessed: Date.now(),
             })
             toast.dismiss("loading-results")
 
             await Promise.all([
-                SessionStore.set('student_exam_no', selectedExamNo),
+                SessionStore.set('student_exam_no', selectedAccount.examNo),
+                SessionStore.set('student_exam_year', selectedAccount.year),
                 SessionStore.set('selected_exam_type', 'bece'),
             ])
             toast.success(`Welcome back, ${result.name}! 🎉`)
@@ -422,7 +438,7 @@ export default function StudentLoginPage() {
         if (showAlternativeForm) params.delete('form')
         else params.set('form', 'alternative')
         setTimeout(() => router.push(`?${params.toString()}`), 0)
-        setError(''); setExamNo(''); setMatchedStudents(null)
+        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null)
         setAltFormData({ fullName: '', schoolName: { id: '', name: '' }, lga: '', examYear: new Date().getFullYear().toString() })
     }
 
@@ -642,6 +658,19 @@ export default function StudentLoginPage() {
                                         ) : (
                                             <p className="mt-2 text-xs text-gray-500">Format: xx/xxx/xxxx/xxx (e.g., ok/977/2025/001)</p>
                                         )}
+                                    </div>
+
+                                    {/* Exam Year */}
+                                    <div className="group relative">
+                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
+                                            Exam Year <span className="text-red-500">*</span>
+                                        </label>
+                                        <CustomDropdown
+                                            options={availableYearOptions}
+                                            value={year}
+                                            onChange={value => { setYear(value); setError('') }}
+                                            placeholder="Select exam year"
+                                        />
                                     </div>
 
                                     {/* Submit */}

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -9,7 +9,7 @@ import animationData from '../../assets/students.json'
 import Image from 'next/image'
 import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
-import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, type FindResultMatch } from '../../store/api/studentApi'
+import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, useFindMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
@@ -174,6 +174,9 @@ export default function StudentLoginPage() {
     const [matchedStudents, setMatchedStudents] = useState<{ studentName: string; id: string }[] | null>(null)
     const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
 
+    const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
+    const [isFindingMatches, setIsFindingMatches] = useState(false)
+
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
         'bece_recent_accounts',
@@ -204,6 +207,7 @@ export default function StudentLoginPage() {
     const [getBECEResult, { isLoading, isFetching, isSuccess }] = useLazyGetBECEResultQuery()
     const [findBECEResult, { isLoading: isFindingResult }] = useFindBECEResultMutation()
     const [createBECEPayment, { isLoading: isCreatingPayment }] = useCreateBECEPaymentMutation()
+    const [findMultipleMatches] = useFindMultipleMatchesMutation()
     const isProcessingPayment = isFindingResult || isCreatingPayment
 
     const { data: schoolNames, isLoading: isLoadingSchoolNames, isFetching: isFetchingSchools } = useGetSchoolNamesQuery(
@@ -236,9 +240,10 @@ export default function StudentLoginPage() {
     // ── Handlers ──────────────────────────────────────────────────────────────
 
     const handleLogin = async (e: React.FormEvent) => {
-        if (isFetching || isLoading || !canProceed) return
+        if (isFetching || isLoading || isFindingMatches || !canProceed) return
         e.preventDefault()
         setError('')
+        setMultiMatchResults(null)
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
         if (!isValidExamNo(examNo)) {
@@ -249,12 +254,60 @@ export default function StudentLoginPage() {
             setError('Please enter a valid exam year'); return
         }
 
+        const rawExamNo = examNo.trim()
+
         try {
-            toast.loading("Loading your results...", {
-                id: "loading-results",
-                duration: Infinity
-            })
-            const result = await getBECEResult({ examNo, year }).unwrap()
+            setIsFindingMatches(true)
+            toast.loading("Checking for matches...", { id: "finding-matches", duration: Infinity })
+            const matches = await findMultipleMatches({ examNumber: rawExamNo, year: parseInt(year) }).unwrap()
+
+            if (matches.length === 0) {
+                setError("No results found for this exam number and year.")
+                toast.dismiss("finding-matches"); toast.error("No results found.")
+                return
+            }
+
+            if (matches.length === 1) {
+                toast.dismiss("finding-matches")
+                await proceedWithResult({ _id: matches[0]._id, examNo: rawExamNo, year })
+                return
+            }
+
+            setMultiMatchResults(matches)
+            toast.dismiss("finding-matches")
+            toast.success(`Found ${matches.length} matches — please select yours.`)
+        } catch (error: unknown) {
+            toast.dismiss("finding-matches");
+            const err = error as { status: string | number }
+            if (err.status === 404) {
+                setError("We couldn't find your results. Check your exam number.")
+                toast.error("We couldn't find your results. Check your exam number.")
+            }
+            else if (err.status === 400) {
+                setError("This exam number doesn't look valid.")
+                toast.error("This exam number doesn't look valid.")
+            }
+            else if (err.status === 500) {
+                setError("Our system is having a moment. Try again shortly.")
+                toast.error("Our system is having a moment. Try again shortly.")
+            }
+            else if (err.status === 'FETCH_ERROR') {
+                setError("No internet connection. Please check and retry.")
+                toast.error("No internet connection. Please check and retry.")
+            }
+            else {
+                setError("Something went wrong. Please try again.")
+                toast.error("Something went wrong. Please try again.")
+            }
+        } finally {
+            setIsFindingMatches(false)
+        }
+    }
+
+    const proceedWithResult = async ({ _id, examNo: rawExamNo, year: yearVal }: { _id: string; examNo: string; year: string }) => {
+        try {
+            toast.loading("Loading your results...", { id: "loading-results", duration: Infinity })
+            const result = await getBECEResult({ _id, year: yearVal }).unwrap()
 
             if (!result?.examNo || !result?.name) {
                 setError("Couldn't load your results. Please try again.")
@@ -262,16 +315,16 @@ export default function StudentLoginPage() {
             }
 
             syncRecentAccount({
-                examNo: examNo,
+                examNo: rawExamNo,
                 studentName: result.name,
                 school: result.school ?? '',
-                year,
+                year: yearVal,
                 lastAccessed: Date.now(),
             })
 
             await Promise.all([
-                SessionStore.set('student_exam_no', examNo),
-                SessionStore.set('student_exam_year', year),
+                SessionStore.set('student_exam_no', rawExamNo),
+                SessionStore.set('student_exam_year', yearVal),
                 SessionStore.set('selected_exam_type', 'bece'),
             ])
 
@@ -302,6 +355,12 @@ export default function StudentLoginPage() {
                 toast.error("Something went wrong. Please try again.")
             }
         }
+    }
+
+    const handleMultiMatchSelect = async (match: MultiMatchResult) => {
+        setSelectedStudentId(match._id)
+        setError('')
+        await proceedWithResult({ _id: match._id, examNo: examNo, year })
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -438,7 +497,7 @@ export default function StudentLoginPage() {
         if (showAlternativeForm) params.delete('form')
         else params.set('form', 'alternative')
         setTimeout(() => router.push(`?${params.toString()}`), 0)
-        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null)
+        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null); setMultiMatchResults(null)
         setAltFormData({ fullName: '', schoolName: { id: '', name: '' }, lga: '', examYear: new Date().getFullYear().toString() })
     }
 
@@ -517,11 +576,13 @@ export default function StudentLoginPage() {
                         <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8 animate-fadeIn-y hover:shadow-2xl transition-all duration-300">
                             <div className="mb-6">
                                 <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : 'Welcome, Student! 👋'}
+                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Select your record' : 'Welcome, Student! 👋'}
                                 </h2>
                                 <p className="text-sm text-gray-600">
                                     {!showAlternativeForm
-                                        ? 'Enter your exam number below to view your BECE results.'
+                                        ? multiMatchResults
+                                            ? `We found ${multiMatchResults.length} records matching your exam number — select the one that belongs to you.`
+                                            : 'Enter your exam number below to view your BECE results.'
                                         : isCreatingPayment
                                             ? 'Please wait while we prepare your payment link.'
                                             : matchedStudents
@@ -532,6 +593,79 @@ export default function StudentLoginPage() {
                             </div>
 
                             {!showAlternativeForm ? (
+                                multiMatchResults ? (
+                                    <div className="space-y-3">
+                                        {error && (
+                                            <div className="bg-red-50 border border-red-200 rounded-lg p-3 flex items-start gap-2">
+                                                <svg className="w-4 h-4 text-red-600 shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" /></svg>
+                                                <p className="text-sm text-red-800 flex-1">{error}</p>
+                                                <button type="button" onClick={() => setError('')} className="text-red-400 hover:text-red-600 ml-1"><IoClose className="w-4 h-4" /></button>
+                                            </div>
+                                        )}
+                                        <motion.div
+                                            className="space-y-2"
+                                            variants={listVariants}
+                                            initial="hidden"
+                                            animate="show"
+                                        >
+                                            {multiMatchResults.map((match) => {
+                                                const isSelected = selectedStudentId === match._id
+                                                const isOther = isLoading && !isSelected
+                                                return (
+                                                    <motion.button
+                                                        key={match._id}
+                                                        variants={itemVariants}
+                                                        type="button"
+                                                        disabled={isLoading}
+                                                        onClick={() => handleMultiMatchSelect(match)}
+                                                        className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl border transition-all duration-150 text-left disabled:cursor-not-allowed ${
+                                                            isSelected
+                                                                ? 'border-green-400 bg-green-50 ring-2 ring-green-200'
+                                                                : isOther
+                                                                    ? 'border-gray-200 bg-gray-50 opacity-40 cursor-not-allowed'
+                                                                    : 'border-gray-200 bg-gray-50 hover:bg-green-50 hover:border-green-300 cursor-pointer'
+                                                        }`}
+                                                    >
+                                                        <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
+                                                            {isSelected
+                                                                ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
+                                                                : getInitials(match.studentName)
+                                                            }
+                                                        </div>
+                                                        <div className="flex-1 min-w-0">
+                                                            <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
+                                                                {match.studentName.toLowerCase()}
+                                                            </p>
+                                                            <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
+                                                                {match.examNo} &middot; {match.examYear}
+                                                            </p>
+                                                        </div>
+                                                        {isSelected
+                                                            ? <span className="w-4 h-4 border-2 border-green-400/40 border-t-green-500 rounded-full animate-spin flex-shrink-0 block" />
+                                                            : <IoChevronForward className="w-4 h-4 flex-shrink-0 text-gray-400" />
+                                                        }
+                                                    </motion.button>
+                                                )
+                                            })}
+                                        </motion.div>
+
+                                        <div className="flex items-center gap-3 pt-1">
+                                            <div className="flex-1 h-px bg-gray-100" />
+                                            <span className="text-xs text-gray-400">not you?</span>
+                                            <div className="flex-1 h-px bg-gray-100" />
+                                        </div>
+
+                                        <button
+                                            type="button"
+                                            disabled={isLoading}
+                                            onClick={() => { setMultiMatchResults(null); setSelectedStudentId(null); setError('') }}
+                                            className="w-full flex items-center justify-center gap-2 py-2.5 text-sm text-gray-500 hover:text-green-600 border border-gray-200 rounded-lg hover:border-green-300 transition-all duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                                        >
+                                            <IoSwapHorizontal className="w-4 h-4" />
+                                            None of these — search again
+                                        </button>
+                                    </div>
+                                ) : (
                                 <form onSubmit={handleLogin} className="space-y-5">
 
                                     {/* ── Recent Accounts ── */}
@@ -697,7 +831,7 @@ export default function StudentLoginPage() {
                                         </button>
                                     </div>
                                 </form>
-                            ) : matchedStudents ? (
+                            )) : matchedStudents ? (
                                 /* ── Student Selection ── */
                                 <div className="space-y-3">
                                     {error && (

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -267,15 +267,9 @@ export default function StudentLoginPage() {
                 return
             }
 
-            if (matches.length === 1) {
-                toast.dismiss("finding-matches")
-                await proceedWithResult({ _id: matches[0]._id, examNo: rawExamNo, year })
-                return
-            }
-
             setMultiMatchResults(matches)
             toast.dismiss("finding-matches")
-            toast.success(`Found ${matches.length} matches — please select yours.`)
+            toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
             toast.dismiss("finding-matches");
             const err = error as { status: string | number }
@@ -576,12 +570,12 @@ export default function StudentLoginPage() {
                         <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8 animate-fadeIn-y hover:shadow-2xl transition-all duration-300">
                             <div className="mb-6">
                                 <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Select your record' : 'Welcome, Student! 👋'}
+                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Is this you? 🔍' : 'Welcome, Student! 👋'}
                                 </h2>
                                 <p className="text-sm text-gray-600">
                                     {!showAlternativeForm
                                         ? multiMatchResults
-                                            ? `We found ${multiMatchResults.length} records matching your exam number — select the one that belongs to you.`
+                                            ? `We found ${multiMatchResults.length} record${multiMatchResults.length !== 1 ? 's' : ''} matching your exam number — select the one that belongs to you.`
                                             : 'Enter your exam number below to view your BECE results.'
                                         : isCreatingPayment
                                             ? 'Please wait while we prepare your payment link.'

--- a/src/app/result-checking/bece/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/bece/dashboard/components/Paywall.tsx
@@ -283,7 +283,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                         {/* Content */}
                         <div className="px-8 py-6">
 
-                            <DetailsCheckBanner examNo={examNo} />
+                            <DetailsCheckBanner examNo={examNo} studentName={studentName} school={school} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/bece/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/bece/dashboard/components/Paywall.tsx
@@ -256,6 +256,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
         })
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         SessionStore.remove('selected_exam_type')
         window.location.href = '/result-checking/bece'
     }

--- a/src/app/result-checking/bece/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/bece/dashboard/components/Paywall.tsx
@@ -284,7 +284,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                         {/* Content */}
                         <div className="px-8 py-6">
 
-                            <DetailsCheckBanner examNo={examNo} studentName={studentName} school={school} />
+                            <DetailsCheckBanner context="paywall" examNo={examNo} studentName={studentName} school={school} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/bece/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/bece/dashboard/components/Paywall.tsx
@@ -8,6 +8,7 @@ import { SessionStore } from '@/app/result-checking/utils/secureStorage'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useSetBecePaymentEmailMutation } from '@/app/result-checking/store/api/studentApi'
 import { isValidEmail } from '@/lib/utils'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 
 
 interface PaywallProps {
@@ -254,6 +255,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
             icon: '👋',
         })
         SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         SessionStore.remove('selected_exam_type')
         window.location.href = '/result-checking/bece'
     }
@@ -280,6 +282,8 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
 
                         {/* Content */}
                         <div className="px-8 py-6">
+
+                            <DetailsCheckBanner examNo={examNo} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { IoLogOut, IoDownload, IoPrint, IoSparkles, IoSwapHorizontal, IoTrophy } from 'react-icons/io5'
 import toast from 'react-hot-toast'
@@ -142,9 +142,10 @@ export default function StudentDashboardPage() {
     }, [router])
 
     // Fetch student data using RTK Query
-    const queryArgs = examId
+    const queryArgs = useMemo(() => examId
         ? { _id: examId }
         : { examNo: examNo || '', year: examYear }
+    , [examId, examNo, examYear])
     const {
         data: student,
         isLoading,

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -34,6 +34,7 @@ export default function StudentDashboardPage() {
     const [isPrinting, setIsPrinting] = useState(false)
     const [examNo, setExamNo] = useState<string | null>(null)
     const [examYear, setExamYear] = useState<string>('')
+    const [examId, setExamId] = useState<string | null>(null)
 
     const getGradeColor = (grade: string) => {
         if (grade === 'A1') return 'bg-gradient-to-r from-yellow-400 to-amber-500 text-white'
@@ -118,8 +119,16 @@ export default function StudentDashboardPage() {
             SessionStore.get('student_exam_no'),
             SessionStore.get('selected_exam_type'),
             SessionStore.get('student_exam_year'),
-        ]).then(([storedExamNo, selectedExamType, storedExamYear]) => {
+            SessionStore.get('student_exam_id'),
+        ]).then(([storedExamNo, selectedExamType, storedExamYear, storedExamId]) => {
             if (cancelled) return
+
+            if (storedExamId) {
+                setExamId(storedExamId)
+                setExamYear(storedExamYear || new Date().getFullYear().toString())
+                return
+            }
+
             if (!storedExamNo || selectedExamType !== 'bece' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
                 toast.error('Invalid exam number. Please log in again.')
                 setTimeout(() => router.push('/result-checking/bece'), 0)
@@ -133,18 +142,22 @@ export default function StudentDashboardPage() {
     }, [router])
 
     // Fetch student data using RTK Query
+    const queryArgs = examId
+        ? { _id: examId }
+        : { examNo: examNo || '', year: examYear }
     const {
         data: student,
         isLoading,
         isError,
         error
-    } = useGetBECEResultQuery({ examNo: examNo || '', year: examYear }, {
-        skip: !examNo || !examYear,
+    } = useGetBECEResultQuery(queryArgs, {
+        skip: !examId && (!examNo || !examYear),
     })
 
     const handleLogout = () => {
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         SessionStore.remove('selected_exam_type')
         toast.success('Logged out successfully')
         setTimeout(() => router.push('/result-checking/bece'), 0)
@@ -154,6 +167,7 @@ export default function StudentDashboardPage() {
         SessionStore.remove('selected_exam_type')
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         toast('Returning to exam selection...', { icon: '🔄' })
         setTimeout(() => router.push('/result-checking'), 0)
     }
@@ -254,7 +268,7 @@ export default function StudentDashboardPage() {
     }
 
     // Show loading while fetching data
-    if (isLoading || !examNo) {
+    if (isLoading || (!examId && !examNo)) {
         return (
             <div className="min-h-screen bg-gradient-to-br from-green-50/30 via-white to-blue-50/30">
                 <header className="bg-white border-b border-gray-100 sticky top-0 z-50">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -32,8 +32,6 @@ export default function StudentDashboardPage() {
     const certificateRef = useRef<HTMLDivElement>(null)
     const [isDownloadingCertificate, setIsDownloadingCertificate] = useState(false)
     const [isPrinting, setIsPrinting] = useState(false)
-    const [examNo, setExamNo] = useState<string | null>(null)
-    const [examYear, setExamYear] = useState<string>('')
     const [examId, setExamId] = useState<string | null>(null)
 
     const getGradeColor = (grade: string) => {
@@ -112,47 +110,33 @@ export default function StudentDashboardPage() {
         }
     }, [searchParams])
 
-    // Get exam number from encrypted localStorage
+    // Get exam id from session
     useEffect(() => {
         let cancelled = false
         Promise.all([
-            SessionStore.get('student_exam_no'),
-            SessionStore.get('selected_exam_type'),
-            SessionStore.get('student_exam_year'),
             SessionStore.get('student_exam_id'),
-        ]).then(([storedExamNo, selectedExamType, storedExamYear, storedExamId]) => {
+            SessionStore.get('selected_exam_type'),
+        ]).then(([storedExamId, selectedExamType]) => {
             if (cancelled) return
-
-            if (storedExamId) {
-                setExamId(storedExamId)
-                setExamYear(storedExamYear || new Date().getFullYear().toString())
-                return
-            }
-
-            if (!storedExamNo || selectedExamType !== 'bece' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
-                toast.error('Invalid exam number. Please log in again.')
+            if (!storedExamId || selectedExamType !== 'bece') {
+                toast.error('Please log in again.')
                 setTimeout(() => router.push('/result-checking/bece'), 0)
                 return
             }
-            const formattedExamNo = storedExamNo.replace(/\//g, '-')
-            setExamNo(formattedExamNo)
-            setExamYear(storedExamYear || new Date().getFullYear().toString())
+            setExamId(storedExamId)
         })
         return () => { cancelled = true }
     }, [router])
 
     // Fetch student data using RTK Query
-    const queryArgs = useMemo(() => examId
-        ? { _id: examId }
-        : { examNo: examNo || '', year: examYear }
-    , [examId, examNo, examYear])
+    const queryArgs = useMemo(() => ({ _id: examId || '' }), [examId])
     const {
         data: student,
         isLoading,
         isError,
         error
     } = useGetBECEResultQuery(queryArgs, {
-        skip: !examId && (!examNo || !examYear),
+        skip: !examId,
     })
 
     const handleLogout = () => {
@@ -269,7 +253,7 @@ export default function StudentDashboardPage() {
     }
 
     // Show loading while fetching data
-    if (isLoading || (!examId && !examNo)) {
+    if (isLoading || !examId) {
         return (
             <div className="min-h-screen bg-gradient-to-br from-green-50/30 via-white to-blue-50/30">
                 <header className="bg-white border-b border-gray-100 sticky top-0 z-50">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -16,6 +16,7 @@ import celebrationData from "./components/celebrationBirthdayEmoji.json"
 import { useMedia } from 'react-use'
 import PortalHeader from '../../components/Portalheader'
 import { SessionStore } from '@/app/result-checking/utils/secureStorage'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 
 // Regex pattern for exam number validation (e.g., XX/000/000)
 const EXAM_NO_REGEX = /^[a-zA-Z]{2}\/\d{1,4}\/\d{1,4}(\(\d\))?$/
@@ -32,6 +33,7 @@ export default function StudentDashboardPage() {
     const [isDownloadingCertificate, setIsDownloadingCertificate] = useState(false)
     const [isPrinting, setIsPrinting] = useState(false)
     const [examNo, setExamNo] = useState<string | null>(null)
+    const [examYear, setExamYear] = useState<string>('')
 
     const getGradeColor = (grade: string) => {
         if (grade === 'A1') return 'bg-gradient-to-r from-yellow-400 to-amber-500 text-white'
@@ -115,7 +117,8 @@ export default function StudentDashboardPage() {
         Promise.all([
             SessionStore.get('student_exam_no'),
             SessionStore.get('selected_exam_type'),
-        ]).then(([storedExamNo, selectedExamType]) => {
+            SessionStore.get('student_exam_year'),
+        ]).then(([storedExamNo, selectedExamType, storedExamYear]) => {
             if (cancelled) return
             if (!storedExamNo || selectedExamType !== 'bece' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
                 toast.error('Invalid exam number. Please log in again.')
@@ -124,6 +127,7 @@ export default function StudentDashboardPage() {
             }
             const formattedExamNo = storedExamNo.replace(/\//g, '-')
             setExamNo(formattedExamNo)
+            setExamYear(storedExamYear || new Date().getFullYear().toString())
         })
         return () => { cancelled = true }
     }, [router])
@@ -134,12 +138,13 @@ export default function StudentDashboardPage() {
         isLoading,
         isError,
         error
-    } = useGetBECEResultQuery(examNo || '', {
-        skip: !examNo,
+    } = useGetBECEResultQuery({ examNo: examNo || '', year: examYear }, {
+        skip: !examNo || !examYear,
     })
 
     const handleLogout = () => {
         SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         SessionStore.remove('selected_exam_type')
         toast.success('Logged out successfully')
         setTimeout(() => router.push('/result-checking/bece'), 0)
@@ -147,6 +152,8 @@ export default function StudentDashboardPage() {
 
     const handleChangeExam = () => {
         SessionStore.remove('selected_exam_type')
+        SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         toast('Returning to exam selection...', { icon: '🔄' })
         setTimeout(() => router.push('/result-checking'), 0)
     }
@@ -436,6 +443,8 @@ export default function StudentDashboardPage() {
                         Academic Year {new Date().getFullYear()}
                     </p>
                 </div>
+
+                <DetailsCheckBanner examNo={student.examNo} />
 
                 {/* Content Grid */}
                 <div className="space-y-6 mb-6">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -444,7 +444,7 @@ export default function StudentDashboardPage() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNo} />
+                <DetailsCheckBanner examNo={student.examNo} studentName={student.name} school={student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-6 mb-6">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -342,7 +342,7 @@ export default function StudentDashboardPage() {
             <Paywall
                 examNo={student.examNo}
                 studentName={student.name}
-                school={student.school}
+                school={student.schoolName || student.school}
             />
         )
     }
@@ -444,7 +444,7 @@ export default function StudentDashboardPage() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNo} studentName={student.name} school={student.school} />
+                <DetailsCheckBanner examNo={student.examNo} studentName={student.name} school={student.schoolName || student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-6 mb-6">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -443,7 +443,7 @@ export default function StudentDashboardPage() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNo} studentName={student.name} school={student.schoolName || student.school} />
+                <DetailsCheckBanner context="dashboard" examNo={student.examNo} studentName={student.name} school={student.schoolName || student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-6 mb-6">

--- a/src/app/result-checking/bece/payment/page.tsx
+++ b/src/app/result-checking/bece/payment/page.tsx
@@ -127,8 +127,9 @@ const storage = {
     async getReturnUrl(): Promise<string> {
         return (await SessionStore.get(STORAGE_KEYS.RETURN_URL)) ?? '/result-checking/bece/dashboard'
     },
-    async saveExamAccess(examNumber: string): Promise<void> {
+    async saveExamAccess(examNumber: string, year?: string): Promise<void> {
         await SessionStore.set(STORAGE_KEYS.EXAM_NO, examNumber)
+        if (year) await SessionStore.set('student_exam_year', year)
         await SessionStore.set(STORAGE_KEYS.EXAM_TYPE, 'bece')
     },
     clearPaymentData(): void {
@@ -315,7 +316,7 @@ function usePaymentVerification(
                         }
 
                         if (response.examNumber) {
-                            await storage.saveExamAccess(response.examNumber)
+                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''))
                             syncRecentAccount({
                                 examNo: response.examNumber,
                                 lastAccessed: Date.now(),

--- a/src/app/result-checking/bece/payment/page.tsx
+++ b/src/app/result-checking/bece/payment/page.tsx
@@ -32,9 +32,11 @@ import { isValidEmail } from '@/lib/utils'
 // ---------------------------------------------------------------------------
 
 interface RecentAccount {
+    _id?: string
     examNo: string
     studentName: string
     school: string
+    year?: string
     lastAccessed: number // Unix ms timestamp
 }
 
@@ -127,9 +129,10 @@ const storage = {
     async getReturnUrl(): Promise<string> {
         return (await SessionStore.get(STORAGE_KEYS.RETURN_URL)) ?? '/result-checking/bece/dashboard'
     },
-    async saveExamAccess(examNumber: string, year?: string): Promise<void> {
+    async saveExamAccess(examNumber: string, year?: string, id?: string): Promise<void> {
         await SessionStore.set(STORAGE_KEYS.EXAM_NO, examNumber)
         if (year) await SessionStore.set('student_exam_year', year)
+        if (id) await SessionStore.set('student_exam_id', id)
         await SessionStore.set(STORAGE_KEYS.EXAM_TYPE, 'bece')
     },
     clearPaymentData(): void {
@@ -316,9 +319,11 @@ function usePaymentVerification(
                         }
 
                         if (response.examNumber) {
-                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''))
+                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''), response._id)
                             syncRecentAccount({
+                                _id: response._id,
                                 examNo: response.examNumber,
+                                year: String(response.examYear || ''),
                                 lastAccessed: Date.now(),
                                 school: built.school || "N/A",
                                 studentName: built.studentName || "N/A"

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { IoClose, IoAlertCircle } from 'react-icons/io5'
+import { updateSearchParam } from '@/lib'
+
+interface DetailsCheckBannerProps {
+  examNo: string
+}
+
+export default function DetailsCheckBanner({ examNo }: DetailsCheckBannerProps) {
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    const key = `details_check_dismissed_${examNo}`
+    const stored = localStorage.getItem(key)
+    if (!stored) setDismissed(false)
+  }, [examNo])
+
+  if (dismissed) return null
+
+  const handleDismiss = () => {
+    const key = `details_check_dismissed_${examNo}`
+    localStorage.setItem(key, 'true')
+    setDismissed(true)
+  }
+
+  const handleReachOut = () => {
+    updateSearchParam('contacting-support', 'true')
+  }
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 relative">
+      <button
+        onClick={handleDismiss}
+        className="absolute top-2 right-2 text-amber-400 hover:text-amber-600 transition-colors cursor-pointer"
+        aria-label="Dismiss"
+      >
+        <IoClose className="w-4 h-4" />
+      </button>
+      <div className="flex items-start gap-3">
+        <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <IoAlertCircle className="w-4 h-4 text-amber-600" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-amber-900 mb-1">
+            Check your details
+          </p>
+          <p className="text-xs text-amber-700 leading-relaxed mb-3">
+            Take a moment to verify that your name, school, and exam number above are correct. If anything is misspelt or incorrect, please reach out to our support team.
+          </p>
+          <button
+            onClick={handleReachOut}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-amber-800 bg-amber-100 hover:bg-amber-200 rounded-lg transition-colors cursor-pointer"
+          >
+            <IoAlertCircle className="w-3.5 h-3.5" />
+            Reach Out to Support
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -1,62 +1,117 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { IoClose, IoAlertCircle } from 'react-icons/io5'
-import { updateSearchParam } from '@/lib'
+import { IoClose, IoLogoWhatsapp } from 'react-icons/io5'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { SessionStore } from '@/app/result-checking/utils/secureStorage'
 
 interface DetailsCheckBannerProps {
   examNo: string
+  studentName?: string
+  school?: string
 }
 
-export default function DetailsCheckBanner({ examNo }: DetailsCheckBannerProps) {
-  const [dismissed, setDismissed] = useState(true)
+export default function DetailsCheckBanner({ examNo, studentName, school }: DetailsCheckBannerProps) {
+  const [open, setOpen] = useState(false)
+  const [examYear, setExamYear] = useState('')
+  const [message, setMessage] = useState('')
 
   useEffect(() => {
     const key = `details_check_dismissed_${examNo}`
     const stored = localStorage.getItem(key)
-    if (!stored) setDismissed(false)
-  }, [examNo])
+    if (!stored) setOpen(true)
 
-  if (dismissed) return null
+    SessionStore.get('student_exam_year').then((year) => {
+      if (year) setExamYear(year)
+    })
+  }, [examNo])
 
   const handleDismiss = () => {
     const key = `details_check_dismissed_${examNo}`
     localStorage.setItem(key, 'true')
-    setDismissed(true)
+    setOpen(false)
   }
 
-  const handleReachOut = () => {
-    updateSearchParam('contacting-support', 'true')
-  }
+  if (!open) return null
+
+  const whatsappText = encodeURIComponent(
+    `Hello, I noticed an issue with my details on the result-checking portal.\n\n${message ? `Issue: ${message}\n\n` : ''}Name: ${studentName || '—'}\nSchool: ${school || '—'}\nExam No: ${examNo}\nYear: ${examYear || '—'}`
+  )
+
+  const whatsappUrl = `https://api.whatsapp.com/send?phone=2349162612656&text=${whatsappText}`
 
   return (
-    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 relative">
-      <button
-        onClick={handleDismiss}
-        className="absolute top-2 right-2 text-amber-400 hover:text-amber-600 transition-colors cursor-pointer"
-        aria-label="Dismiss"
-      >
-        <IoClose className="w-4 h-4" />
-      </button>
-      <div className="flex items-start gap-3">
-        <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0 mt-0.5">
-          <IoAlertCircle className="w-4 h-4 text-amber-600" />
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-lg">Check Your Details</DialogTitle>
+          <DialogDescription>
+            Please review the details below. If anything is incorrect, let us know via WhatsApp and we&apos;ll help fix it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 bg-gray-50 rounded-xl p-4">
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-500">Name</span>
+            <span className="font-medium text-gray-900 capitalize text-right max-w-[60%]">
+              {studentName?.toLowerCase() || '—'}
+            </span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-500">School</span>
+            <span className="font-medium text-gray-900 capitalize text-right max-w-[60%]">
+              {school?.toLowerCase() || '—'}
+            </span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-500">Exam Number</span>
+            <span className="font-mono text-xs font-medium text-gray-900 uppercase">
+              {examNo}
+            </span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-500">Year</span>
+            <span className="font-medium text-gray-900">{examYear || '—'}</span>
+          </div>
         </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-amber-900 mb-1">
-            Check your details
-          </p>
-          <p className="text-xs text-amber-700 leading-relaxed mb-3">
-            Take a moment to verify that your name, school, and exam number above are correct. If anything is misspelt or incorrect, please reach out to our support team.
-          </p>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-gray-700">
+            Describe the issue <span className="text-gray-400">(optional)</span>
+          </label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="e.g. My name is misspelt, the school name is wrong..."
+            rows={3}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-green-100 focus:border-green-500"
+          />
+        </div>
+
+        <DialogFooter className="sm:justify-between gap-3">
           <button
-            onClick={handleReachOut}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-amber-800 bg-amber-100 hover:bg-amber-200 rounded-lg transition-colors cursor-pointer"
+            onClick={handleDismiss}
+            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
           >
-            <IoAlertCircle className="w-3.5 h-3.5" />
-            Reach Out to Support
+            Looks good, dismiss
           </button>
-        </div>
-      </div>
-    </div>
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm"
+          >
+            <IoLogoWhatsapp className="w-4 h-4" />
+            Reach Out via WhatsApp
+          </a>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -21,6 +21,7 @@ export default function DetailsCheckBanner({ examNo, studentName, school }: Deta
   const [open, setOpen] = useState(false)
   const [examYear, setExamYear] = useState('')
   const [message, setMessage] = useState('')
+  const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || '2349162612656'
 
   useEffect(() => {
     const key = `details_check_dismissed_${examNo}`
@@ -44,7 +45,7 @@ export default function DetailsCheckBanner({ examNo, studentName, school }: Deta
     `Hello, I noticed an issue with my details on the result-checking portal.\n\n${message ? `Issue: ${message}\n\n` : ''}Name: ${studentName || '—'}\nSchool: ${school || '—'}\nExam No: ${examNo}\nYear: ${examYear || '—'}`
   )
 
-  const whatsappUrl = `https://api.whatsapp.com/send?phone=2349162612656&text=${whatsappText}`
+  const whatsappUrl = `https://api.whatsapp.com/send?phone=${whatsappNumber}&text=${whatsappText}`
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -15,28 +15,31 @@ interface DetailsCheckBannerProps {
   examNo: string
   studentName?: string
   school?: string
+  context: 'paywall' | 'dashboard' | 'retrieval'
+  onDismiss?: () => void
 }
 
-export default function DetailsCheckBanner({ examNo, studentName, school }: DetailsCheckBannerProps) {
+export default function DetailsCheckBanner({ examNo, studentName, school, context, onDismiss }: DetailsCheckBannerProps) {
   const [open, setOpen] = useState(false)
   const [examYear, setExamYear] = useState('')
   const [message, setMessage] = useState('')
   const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || '2349162612656'
 
   useEffect(() => {
-    const key = `details_check_dismissed_${examNo}`
+    const key = `details_check_dismissed_${context}_${examNo}`
     const stored = localStorage.getItem(key)
     if (!stored) setOpen(true)
 
     SessionStore.get('student_exam_year').then((year) => {
       if (year) setExamYear(year)
     })
-  }, [examNo])
+  }, [examNo, context])
 
   const handleDismiss = () => {
-    const key = `details_check_dismissed_${examNo}`
+    const key = `details_check_dismissed_${context}_${examNo}`
     localStorage.setItem(key, 'true')
     setOpen(false)
+    onDismiss?.()
   }
 
   if (!open) return null

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -278,6 +278,19 @@ export const studentApi = apiSlice.injectEndpoints({
                 method: 'POST',
                 body: data,
             }),
+            transformResponse: async (response: unknown) => {
+                const raw = response as { data?: unknown }
+                if (typeof raw?.data === 'string') {
+                    if (!(await isApiResponseDecryptConfigured())) return response as MultiMatchResult[]
+                    try {
+                        return await decryptApiResponseFrom<MultiMatchResult[]>(raw as { data: string }, 'data')
+                    } catch (e) {
+                        console.warn('apiResponseFunnel: decrypt failed, using raw response. Check API_RESPONSE_DECRYPT_SECRET and backend key/salt match.', e)
+                        return response as MultiMatchResult[]
+                    }
+                }
+                return response as MultiMatchResult[]
+            },
         }),
     }),
     overrideExisting: true,

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -116,9 +116,9 @@ export interface CustomerSupport {
 export const studentApi = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
         // Get UBEAT student result by exam number
-        getUBEATResult: builder.query<UBEATStudentResult, string>({
-            query: (examNo) => ({
-                url: `${API_BASE_URL}/ubeat/result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}`,
+        getUBEATResult: builder.query<UBEATStudentResult, { examNo: string; year: string }>({
+            query: ({ examNo, year }) => ({
+                url: `${API_BASE_URL}/ubeat/result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year)}`,
                 method: 'GET',
             }),
             transformResponse: async (response: unknown) => {
@@ -132,7 +132,7 @@ export const studentApi = apiSlice.injectEndpoints({
                     return response as UBEATStudentResult
                 }
             },
-            providesTags: (result, error, examNo) => [
+            providesTags: (result, error, { examNo }) => [
                 { type: 'Students', id: `UBEAT-${examNo}` }
             ],
         }),
@@ -229,10 +229,18 @@ export const studentApi = apiSlice.injectEndpoints({
             }),
         }),
 
+        // Get available exam years
+        getAvailableYears: builder.query<{ years: number[] }, void>({
+            query: () => ({
+                url: `${API_BASE_URL}/ubeat/available-years`,
+                method: 'GET',
+            }),
+        }),
+
         // Get BECE student result by exam number
-        getBECEResult: builder.query<BECEStudentResult, string>({
-            query: (examNo) => ({
-                url: `${API_BASE_URL}/bece-student/check-result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}`,
+        getBECEResult: builder.query<BECEStudentResult, { examNo: string; year: string }>({
+            query: ({ examNo, year }) => ({
+                url: `${API_BASE_URL}/bece-student/check-result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year)}`,
                 method: 'GET',
             }),
             transformResponse: async (response: unknown) => {
@@ -246,7 +254,7 @@ export const studentApi = apiSlice.injectEndpoints({
                     return response as BECEStudentResult
                 }
             },
-            providesTags: (result, error, examNo) => [
+            providesTags: (result, error, { examNo }) => [
                 { type: 'Students', id: `BECE-${examNo}` }
             ],
         }),
@@ -258,6 +266,7 @@ export const studentApi = apiSlice.injectEndpoints({
 export const {
     useGetUBEATResultQuery,
     useGetBECEResultQuery,
+    useGetAvailableYearsQuery,
     useLazyGetUBEATResultQuery,
     useLazyGetBECEResultQuery,
     useFindUBEATResultMutation,

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -99,6 +99,14 @@ export interface FindResultRequest {
     lga: string
 }
 
+// Match returned by find-multiple-matches endpoint
+export interface MultiMatchResult {
+    _id: string
+    studentName: string
+    examNo: string
+    examYear: number
+}
+
 export interface CustomerSupport {
     fullName: string,
     lga: LgaEnum,
@@ -115,10 +123,12 @@ export interface CustomerSupport {
 // Extend the apiSlice with student portal endpoints
 export const studentApi = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
-        // Get UBEAT student result by exam number
-        getUBEATResult: builder.query<UBEATStudentResult, { examNo: string; year: string }>({
-            query: ({ examNo, year }) => ({
-                url: `${API_BASE_URL}/ubeat/result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year)}`,
+        // Get UBEAT student result by exam number or _id
+        getUBEATResult: builder.query<UBEATStudentResult, { _id?: string; examNo?: string; year?: string }>({
+            query: ({ _id, examNo, year }) => ({
+                url: _id
+                    ? `${API_BASE_URL}/ubeat/result/${_id}?year=${encodeURIComponent(year || '')}`
+                    : `${API_BASE_URL}/ubeat/result/${encodeURIComponent((examNo || '').replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year || '')}`,
                 method: 'GET',
             }),
             transformResponse: async (response: unknown) => {
@@ -132,8 +142,8 @@ export const studentApi = apiSlice.injectEndpoints({
                     return response as UBEATStudentResult
                 }
             },
-            providesTags: (result, error, { examNo }) => [
-                { type: 'Students', id: `UBEAT-${examNo}` }
+            providesTags: (result, error, { _id, examNo }) => [
+                { type: 'Students', id: `UBEAT-${_id || examNo}` }
             ],
         }),
 
@@ -237,10 +247,12 @@ export const studentApi = apiSlice.injectEndpoints({
             }),
         }),
 
-        // Get BECE student result by exam number
-        getBECEResult: builder.query<BECEStudentResult, { examNo: string; year: string }>({
-            query: ({ examNo, year }) => ({
-                url: `${API_BASE_URL}/bece-student/check-result/${encodeURIComponent(examNo.replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year)}`,
+        // Get BECE student result by exam number or _id
+        getBECEResult: builder.query<BECEStudentResult, { _id?: string; examNo?: string; year?: string }>({
+            query: ({ _id, examNo, year }) => ({
+                url: _id
+                    ? `${API_BASE_URL}/bece-student/check-result/${_id}?year=${encodeURIComponent(year || '')}`
+                    : `${API_BASE_URL}/bece-student/check-result/${encodeURIComponent((examNo || '').replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year || '')}`,
                 method: 'GET',
             }),
             transformResponse: async (response: unknown) => {
@@ -254,9 +266,18 @@ export const studentApi = apiSlice.injectEndpoints({
                     return response as BECEStudentResult
                 }
             },
-            providesTags: (result, error, { examNo }) => [
-                { type: 'Students', id: `BECE-${examNo}` }
+            providesTags: (result, error, { _id, examNo }) => [
+                { type: 'Students', id: `BECE-${_id || examNo}` }
             ],
+        }),
+
+        // Find multiple matches for UBEAT exam number
+        findMultipleMatches: builder.mutation<MultiMatchResult[], { examNumber: string; year: number }>({
+            query: (data) => ({
+                url: `${API_BASE_URL}/ubeat/result/find-multiple-matches`,
+                method: 'POST',
+                body: data,
+            }),
         }),
     }),
     overrideExisting: true,
@@ -275,5 +296,6 @@ export const {
     useCreateUBEATPaymentMutation,
     useCustomerSupportMutation,
     useSetBecePaymentEmailMutation,
-    useSetUbeatPaymentEmailMutation
+    useSetUbeatPaymentEmailMutation,
+    useFindMultipleMatchesMutation,
 } = studentApi

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -102,9 +102,17 @@ export interface FindResultRequest {
 // Match returned by find-multiple-matches endpoint
 export interface MultiMatchResult {
     _id: string
-    studentName: string
+    name: string
     examNo: string
     examYear: number
+    school?: {
+        _id: string
+        schoolName: string
+        lga?: string
+        schoolCode?: string
+    }
+    subjects?: Array<{ name: string; exam: number }>
+    isPaid?: boolean
 }
 
 export interface CustomerSupport {
@@ -251,7 +259,7 @@ export const studentApi = apiSlice.injectEndpoints({
         getBECEResult: builder.query<BECEStudentResult, { _id?: string; examNo?: string; year?: string }>({
             query: ({ _id, examNo, year }) => ({
                 url: _id
-                    ? `${API_BASE_URL}/bece-student/check-result/${_id}?year=${encodeURIComponent(year || '')}`
+                    ? `${API_BASE_URL}/bece-student/check-result/${_id}`
                     : `${API_BASE_URL}/bece-student/check-result/${encodeURIComponent((examNo || '').replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year || '')}`,
                 method: 'GET',
             }),
@@ -284,8 +292,29 @@ export const studentApi = apiSlice.injectEndpoints({
                     if (!(await isApiResponseDecryptConfigured())) return response as MultiMatchResult[]
                     try {
                         const result = await decryptApiResponseFrom<MultiMatchResult[]>(raw as { data: string }, 'data')
-                        console.log('findMultipleMatches decrypted result:', result)
                         return result
+                    } catch (e) {
+                        console.warn('apiResponseFunnel: decrypt failed, using raw response. Check API_RESPONSE_DECRYPT_SECRET and backend key/salt match.', e)
+                        return response as MultiMatchResult[]
+                    }
+                }
+                return response as MultiMatchResult[]
+            },
+        }),
+
+        // Find multiple matches for BECE exam number
+        findBECEMultipleMatches: builder.mutation<MultiMatchResult[], { examNumber: string; year: number }>({
+            query: (data) => ({
+                url: `${API_BASE_URL}/bece-student/result/find-multiple-matches`,
+                method: 'POST',
+                body: data,
+            }),
+            transformResponse: async (response: unknown) => {
+                const raw = response as { data?: unknown }
+                if (typeof raw?.data === 'string') {
+                    if (!(await isApiResponseDecryptConfigured())) return response as MultiMatchResult[]
+                    try {
+                        return await decryptApiResponseFrom<MultiMatchResult[]>(raw as { data: string }, 'data')
                     } catch (e) {
                         console.warn('apiResponseFunnel: decrypt failed, using raw response. Check API_RESPONSE_DECRYPT_SECRET and backend key/salt match.', e)
                         return response as MultiMatchResult[]
@@ -313,4 +342,5 @@ export const {
     useSetBecePaymentEmailMutation,
     useSetUbeatPaymentEmailMutation,
     useFindMultipleMatchesMutation,
+    useFindBECEMultipleMatchesMutation,
 } = studentApi

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -127,7 +127,7 @@ export const studentApi = apiSlice.injectEndpoints({
         getUBEATResult: builder.query<UBEATStudentResult, { _id?: string; examNo?: string; year?: string }>({
             query: ({ _id, examNo, year }) => ({
                 url: _id
-                    ? `${API_BASE_URL}/ubeat/result/${_id}?year=${encodeURIComponent(year || '')}`
+                    ? `${API_BASE_URL}/ubeat/result/${_id}`
                     : `${API_BASE_URL}/ubeat/result/${encodeURIComponent((examNo || '').replace(/\s/g, '').replace(/\//g, '-'))}?year=${encodeURIComponent(year || '')}`,
                 method: 'GET',
             }),
@@ -283,7 +283,9 @@ export const studentApi = apiSlice.injectEndpoints({
                 if (typeof raw?.data === 'string') {
                     if (!(await isApiResponseDecryptConfigured())) return response as MultiMatchResult[]
                     try {
-                        return await decryptApiResponseFrom<MultiMatchResult[]>(raw as { data: string }, 'data')
+                        const result = await decryptApiResponseFrom<MultiMatchResult[]>(raw as { data: string }, 'data')
+                        console.log('findMultipleMatches decrypted result:', result)
+                        return result
                     } catch (e) {
                         console.warn('apiResponseFunnel: decrypt failed, using raw response. Check API_RESPONSE_DECRYPT_SECRET and backend key/salt match.', e)
                         return response as MultiMatchResult[]

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -240,9 +240,9 @@ export const studentApi = apiSlice.injectEndpoints({
         }),
 
         // Get available exam years
-        getAvailableYears: builder.query<{ years: number[] }, void>({
-            query: () => ({
-                url: `${API_BASE_URL}/ubeat/available-years`,
+        getAvailableYears: builder.query<{ years: number[] }, { examType: 'ubeat' | 'bece' }>({
+            query: ({ examType }) => ({
+                url: `${API_BASE_URL}/students/available-years?examType=${examType.toUpperCase()}`,
                 method: 'GET',
             }),
         }),

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -747,7 +747,7 @@ export default function UBEATLogin() {
                                                 id="examNo"
                                                 value={examNo}
                                                 onChange={e => { setExamNo(e.target.value.toLowerCase()); setError('') }}
-                                                placeholder="e.g., ok/977/2025/001"
+                                                placeholder="XX/XXX/XXX"
                                                 className={`block w-full pl-10 pr-3 py-3 border rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent hover:border-green-400 transition-all duration-200 uppercase ${error
                                                     ? 'border-red-300 bg-red-50'
                                                     : debouncedExamNo && !canProceed && debouncedExamNo.length > 0

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
 import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, useGetAvailableYearsQuery, useFindMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import { SessionStore, useSecureSessionStorage } from '@/app/result-checking/utils/secureStorage'
 import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
@@ -175,6 +176,7 @@ export default function UBEATLogin() {
 
     const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
     const [isFindingMatches, setIsFindingMatches] = useState(false)
+    const [confirmMatch, setConfirmMatch] = useState<MultiMatchResult | null>(null)
 
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
@@ -356,7 +358,7 @@ export default function UBEATLogin() {
     const handleMultiMatchSelect = async (match: MultiMatchResult) => {
         setSelectedStudentId(match._id)
         setError('')
-        await proceedWithResult({ _id: match._id, examNo: examNo, year })
+        setConfirmMatch(match)
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -623,12 +625,12 @@ export default function UBEATLogin() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.studentName)
+                                                                : getInitials(match.name)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.studentName.toLowerCase()}
+                                                                {match.name.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1055,6 +1057,20 @@ export default function UBEATLogin() {
                                 <strong>📝 Note:</strong> Use your official UBEAT exam number from your school.
                             </p>
                         </div>
+                    )}
+
+                    {confirmMatch && (
+                        <DetailsCheckBanner
+                            context="retrieval"
+                            examNo={confirmMatch.examNo}
+                            studentName={confirmMatch.name}
+                            school={confirmMatch.school?.schoolName}
+                            onDismiss={() => {
+                                const match = confirmMatch
+                                setConfirmMatch(null)
+                                proceedWithResult({ _id: match._id, examNo: examNo, year })
+                            }}
+                        />
                     )}
 
                     <div className="mt-6 text-center">

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -266,15 +266,9 @@ export default function UBEATLogin() {
                 return
             }
 
-            if (matches.length === 1) {
-                toast.dismiss("finding-matches")
-                await proceedWithResult({ _id: matches[0]._id, examNo: rawExamNo, year })
-                return
-            }
-
             setMultiMatchResults(matches)
             toast.dismiss("finding-matches")
-            toast.success(`Found ${matches.length} matches — please select yours.`)
+            toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
             toast.dismiss("finding-matches");
             const err = error as { status: string | number }
@@ -569,12 +563,12 @@ export default function UBEATLogin() {
                         <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8 animate-fadeIn-y hover:shadow-2xl transition-all duration-300">
                             <div className="mb-6">
                                 <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Select your record' : 'Welcome, Student! 👋'}
+                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Is this you? 🔍' : 'Welcome, Student! 👋'}
                                 </h2>
                                 <p className="text-sm text-gray-600">
                                     {!showAlternativeForm
                                         ? multiMatchResults
-                                            ? `We found ${multiMatchResults.length} records matching your exam number — select the one that belongs to you.`
+                                            ? `We found ${multiMatchResults.length} record${multiMatchResults.length !== 1 ? 's' : ''} matching your exam number — select the one that belongs to you.`
                                             : 'Enter your exam number below to view your UBEAT results.'
                                         : isCreatingPayment
                                             ? 'Please wait while we prepare your payment link.'

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -10,7 +10,7 @@ import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
-import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, type FindResultMatch } from '../../store/api/studentApi'
+import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, useGetAvailableYearsQuery, type FindResultMatch } from '../../store/api/studentApi'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import { SessionStore, useSecureSessionStorage } from '@/app/result-checking/utils/secureStorage'
 import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
@@ -30,6 +30,7 @@ interface RecentAccount {
     examNo: string
     studentName: string
     school: string
+    year: string
     lastAccessed: number // Unix ms timestamp
 }
 
@@ -95,7 +96,7 @@ function RecentAccountCard({
     isLoading,
 }: {
     account: RecentAccount
-    onSelect: (examNo: string) => void
+    onSelect: (account: RecentAccount) => void
     onRemove: (examNo: string) => void
     isLoading: boolean
 }) {
@@ -104,7 +105,7 @@ function RecentAccountCard({
             variants={itemVariants}
             layout
             className={`group relative flex items-center gap-3 px-3 py-2.5 rounded-xl border border-gray-100 bg-gray-50 hover:bg-green-50 hover:border-green-200 transition-all duration-150 cursor-pointer ${isLoading ? 'opacity-50 cursor-not-allowed grayscale-50' : ''}`}
-            onClick={!isLoading ? () => onSelect(account.examNo) : () => { }}
+            onClick={!isLoading ? () => onSelect(account) : () => { }}
         >
             {/* Avatar */}
             <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
@@ -119,6 +120,7 @@ function RecentAccountCard({
                 <p className="text-xs text-gray-400 truncate font-mono uppercase">
                     {account.examNo}
                 </p>
+                <p className="text-[10px] text-gray-400">{account.year}</p>
             </div>
 
             {/* Time + arrow */}
@@ -146,6 +148,7 @@ export default function UBEATLogin() {
     const searchParams = useSearchParams()
 
     const [examNo, setExamNo] = useState('')
+    const [year, setYear] = useState('')
     const [error, setError] = useState('')
     const [showAllAccounts, setShowAllAccounts] = useState(false)
 
@@ -207,11 +210,16 @@ export default function UBEATLogin() {
         { skip: !altFormData.lga },
     )
 
+    const { data: availableYearsData } = useGetAvailableYearsQuery()
+    const availableYearOptions = useMemo(() => {
+        return (availableYearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) }))
+    }, [availableYearsData])
+
     const schoolNamesList = useMemo(() => schoolNames ?? [], [schoolNames])
     const lgaOptions = useMemo(() => IMO_STATE_LGAS.map(lga => ({ value: lga, label: lga })), [])
 
     const debouncedExamNo = useDebounce(examNo, 500)
-    const canProceed = debouncedExamNo.length >= 6 && isValidExamNo(debouncedExamNo)
+    const canProceed = debouncedExamNo.length >= 6 && isValidExamNo(debouncedExamNo) && year.trim().length === 4
 
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
     const isMaintenanceMode = !API_BASE_URL
@@ -236,13 +244,16 @@ export default function UBEATLogin() {
             setError("Invalid format. Try: ok/977/2025/001")
             return
         }
+        if (!year.trim() || year.trim().length !== 4) {
+            setError('Please enter a valid exam year'); return
+        }
 
         try {
             toast.loading("Loading your results...", {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getUBEATResult(examNo).unwrap()
+            const result = await getUBEATResult({ examNo, year }).unwrap()
 
             if (!result?.examNumber || !result?.studentName) {
                 setError("Couldn't load your results. Please try again.")
@@ -253,11 +264,13 @@ export default function UBEATLogin() {
                 examNo: examNo,
                 studentName: result.studentName,
                 school: result.schoolName ?? result.school ?? '',
+                year,
                 lastAccessed: Date.now(),
             })
 
             await Promise.all([
                 SessionStore.set('student_exam_no', examNo),
+                SessionStore.set('student_exam_year', year),
                 SessionStore.set('selected_exam_type', 'ubeat'),
             ])
 
@@ -291,8 +304,9 @@ export default function UBEATLogin() {
         }
     }
 
-    const handleSelectRecent = async (selectedExamNo: string) => {
-        setExamNo(selectedExamNo)
+    const handleSelectRecent = async (selectedAccount: RecentAccount) => {
+        setExamNo(selectedAccount.examNo)
+        setYear(selectedAccount.year)
         setError('')
 
         try {
@@ -300,22 +314,24 @@ export default function UBEATLogin() {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getUBEATResult(selectedExamNo).unwrap()
+            const result = await getUBEATResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
             if (!result?.examNumber || !result?.studentName) {
                 setError("Couldn't load results for this account.")
                 return
             }
 
             syncRecentAccount({
-                examNo: selectedExamNo,
+                examNo: selectedAccount.examNo,
                 studentName: result.studentName,
                 school: result.schoolName ?? result.school ?? '',
+                year: selectedAccount.year,
                 lastAccessed: Date.now(),
             })
             toast.dismiss("loading-results")
 
             await Promise.all([
-                SessionStore.set('student_exam_no', selectedExamNo),
+                SessionStore.set('student_exam_no', selectedAccount.examNo),
+                SessionStore.set('student_exam_year', selectedAccount.year),
                 SessionStore.set('selected_exam_type', 'ubeat'),
             ])
             toast.success(`Welcome back, ${result.studentName}! 🎉`)
@@ -415,7 +431,7 @@ export default function UBEATLogin() {
         if (showAlternativeForm) params.delete('form')
         else params.set('form', 'alternative')
         setTimeout(() => router.push(`?${params.toString()}`), 0)
-        setError(''); setExamNo(''); setMatchedStudents(null)
+        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null)
         setAltFormData({ fullName: '', schoolName: { id: '', name: '' }, lga: '', examYear: new Date().getFullYear().toString() })
     }
 
@@ -636,6 +652,19 @@ export default function UBEATLogin() {
                                         ) : (
                                             <p className="mt-2 text-xs text-gray-500">Format: xx/xxx/xxxx/xxx (e.g., ok/977/2025/001)</p>
                                         )}
+                                    </div>
+
+                                    {/* Exam Year */}
+                                    <div className="group relative">
+                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
+                                            Exam Year <span className="text-red-500">*</span>
+                                        </label>
+                                        <CustomDropdown
+                                            options={availableYearOptions}
+                                            value={year}
+                                            onChange={value => { setYear(value); setError('') }}
+                                            placeholder="Select exam year"
+                                        />
                                     </div>
 
                                     {/* Submit */}

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -27,6 +27,7 @@ const IMO_STATE_LGAS = Object.values(LgaEnum);
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface RecentAccount {
+    _id?: string
     examNo: string
     studentName: string
     school: string
@@ -308,6 +309,7 @@ export default function UBEATLogin() {
             }
 
             syncRecentAccount({
+                _id,
                 examNo: rawExamNo,
                 studentName: result.studentName,
                 school: result.schoolName ?? result.school ?? '',
@@ -318,6 +320,7 @@ export default function UBEATLogin() {
             await Promise.all([
                 SessionStore.set('student_exam_no', rawExamNo),
                 SessionStore.set('student_exam_year', yearVal),
+                SessionStore.set('student_exam_id', _id),
                 SessionStore.set('selected_exam_type', 'ubeat'),
             ])
 
@@ -366,13 +369,16 @@ export default function UBEATLogin() {
                 id: "loading-results",
                 duration: Infinity
             })
-            const result = await getUBEATResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
+            const result = selectedAccount._id
+                ? await getUBEATResult({ _id: selectedAccount._id }).unwrap()
+                : await getUBEATResult({ examNo: selectedAccount.examNo, year: selectedAccount.year }).unwrap()
             if (!result?.examNumber || !result?.studentName) {
                 setError("Couldn't load results for this account.")
                 return
             }
 
             syncRecentAccount({
+                _id: selectedAccount._id,
                 examNo: selectedAccount.examNo,
                 studentName: result.studentName,
                 school: result.schoolName ?? result.school ?? '',
@@ -384,6 +390,7 @@ export default function UBEATLogin() {
             await Promise.all([
                 SessionStore.set('student_exam_no', selectedAccount.examNo),
                 SessionStore.set('student_exam_year', selectedAccount.year),
+                ...(selectedAccount._id ? [SessionStore.set('student_exam_id', selectedAccount._id)] : []),
                 SessionStore.set('selected_exam_type', 'ubeat'),
             ])
             toast.success(`Welcome back, ${result.studentName}! 🎉`)

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -214,7 +214,7 @@ export default function UBEATLogin() {
         { skip: !altFormData.lga },
     )
 
-    const { data: availableYearsData } = useGetAvailableYearsQuery()
+    const { data: availableYearsData } = useGetAvailableYearsQuery({ examType: 'ubeat' })
     const availableYearOptions = useMemo(() => {
         return (availableYearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) }))
     }, [availableYearsData])

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -10,7 +10,7 @@ import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
-import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, useGetAvailableYearsQuery, type FindResultMatch } from '../../store/api/studentApi'
+import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, useGetAvailableYearsQuery, useFindMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import { SessionStore, useSecureSessionStorage } from '@/app/result-checking/utils/secureStorage'
 import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
@@ -172,6 +172,9 @@ export default function UBEATLogin() {
     const [matchedStudents, setMatchedStudents] = useState<{ studentName: string; id: string }[] | null>(null)
     const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
 
+    const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
+    const [isFindingMatches, setIsFindingMatches] = useState(false)
+
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
         'ubeat_recent_accounts',
@@ -203,6 +206,7 @@ export default function UBEATLogin() {
     const [getUBEATResult, { isLoading, isFetching: isFetchingResult }] = useLazyGetUBEATResultQuery()
     const [findUBEATResult, { isLoading: isFindingResult }] = useFindUBEATResultMutation()
     const [createUBEATPayment, { isLoading: isCreatingPayment }] = useCreateUBEATPaymentMutation()
+    const [findMultipleMatches] = useFindMultipleMatchesMutation()
     const isProcessingPayment = isFindingResult || isCreatingPayment
 
     const { data: schoolNames, isLoading: isLoadingSchoolNames, isFetching } = useGetSchoolNamesQuery(
@@ -235,9 +239,10 @@ export default function UBEATLogin() {
     // ── Handlers ──────────────────────────────────────────────────────────────
 
     const handleLogin = async (e: React.FormEvent) => {
-        if (isFetchingResult || isLoading || !canProceed) return
+        if (isFetchingResult || isLoading || isFindingMatches || !canProceed) return
         e.preventDefault()
         setError('')
+        setMultiMatchResults(null)
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
         if (!isValidExamNo(examNo)) {
@@ -248,12 +253,60 @@ export default function UBEATLogin() {
             setError('Please enter a valid exam year'); return
         }
 
+        const rawExamNo = examNo.trim()
+
         try {
-            toast.loading("Loading your results...", {
-                id: "loading-results",
-                duration: Infinity
-            })
-            const result = await getUBEATResult({ examNo, year }).unwrap()
+            setIsFindingMatches(true)
+            toast.loading("Checking for matches...", { id: "finding-matches", duration: Infinity })
+            const matches = await findMultipleMatches({ examNumber: rawExamNo, year: parseInt(year) }).unwrap()
+
+            if (matches.length === 0) {
+                setError("No results found for this exam number and year.")
+                toast.dismiss("finding-matches"); toast.error("No results found.")
+                return
+            }
+
+            if (matches.length === 1) {
+                toast.dismiss("finding-matches")
+                await proceedWithResult({ _id: matches[0]._id, examNo: rawExamNo, year })
+                return
+            }
+
+            setMultiMatchResults(matches)
+            toast.dismiss("finding-matches")
+            toast.success(`Found ${matches.length} matches — please select yours.`)
+        } catch (error: unknown) {
+            toast.dismiss("finding-matches");
+            const err = error as { status: string | number }
+            if (err.status === 404) {
+                setError("We couldn't find your results. Check your exam number.");
+                toast.error("We couldn't find your results. Check your exam number.")
+            }
+            else if (err.status === 400) {
+                setError("This exam number doesn't look valid.");
+                toast.error("This exam number doesn't look valid.")
+            }
+            else if (err.status === 500) {
+                setError("Our system is having a moment. Try again shortly.");
+                toast.error("Our system is having a moment. Try again shortly.")
+            }
+            else if (err.status === 'FETCH_ERROR') {
+                setError("No internet connection. Please check and retry.");
+                toast.error("No internet connection. Please check and retry.")
+            }
+            else {
+                setError("Something went wrong. Please try again.");
+                toast.error("Something went wrong. Please try again.")
+            }
+        } finally {
+            setIsFindingMatches(false)
+        }
+    }
+
+    const proceedWithResult = async ({ _id, examNo: rawExamNo, year: yearVal }: { _id: string; examNo: string; year: string }) => {
+        try {
+            toast.loading("Loading your results...", { id: "loading-results", duration: Infinity })
+            const result = await getUBEATResult({ _id, year: yearVal }).unwrap()
 
             if (!result?.examNumber || !result?.studentName) {
                 setError("Couldn't load your results. Please try again.")
@@ -261,21 +314,20 @@ export default function UBEATLogin() {
             }
 
             syncRecentAccount({
-                examNo: examNo,
+                examNo: rawExamNo,
                 studentName: result.studentName,
                 school: result.schoolName ?? result.school ?? '',
-                year,
+                year: yearVal,
                 lastAccessed: Date.now(),
             })
 
             await Promise.all([
-                SessionStore.set('student_exam_no', examNo),
-                SessionStore.set('student_exam_year', year),
+                SessionStore.set('student_exam_no', rawExamNo),
+                SessionStore.set('student_exam_year', yearVal),
                 SessionStore.set('selected_exam_type', 'ubeat'),
             ])
 
             toast.dismiss("loading-results");
-
             toast.success(`Welcome ${result.studentName}! Loading your results... 🎉`)
             setTimeout(() => router.push('/result-checking/ubeat/dashboard'), 0)
         } catch (error: unknown) {
@@ -302,6 +354,12 @@ export default function UBEATLogin() {
                 toast.error("Something went wrong. Please try again.")
             }
         }
+    }
+
+    const handleMultiMatchSelect = async (match: MultiMatchResult) => {
+        setSelectedStudentId(match._id)
+        setError('')
+        await proceedWithResult({ _id: match._id, examNo: examNo, year })
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -431,7 +489,7 @@ export default function UBEATLogin() {
         if (showAlternativeForm) params.delete('form')
         else params.set('form', 'alternative')
         setTimeout(() => router.push(`?${params.toString()}`), 0)
-        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null)
+        setError(''); setExamNo(''); setYear(''); setMatchedStudents(null); setMultiMatchResults(null)
         setAltFormData({ fullName: '', schoolName: { id: '', name: '' }, lga: '', examYear: new Date().getFullYear().toString() })
     }
 
@@ -511,11 +569,13 @@ export default function UBEATLogin() {
                         <div className="bg-white rounded-2xl shadow-xl border border-gray-200 p-8 animate-fadeIn-y hover:shadow-2xl transition-all duration-300">
                             <div className="mb-6">
                                 <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : 'Welcome, Student! 👋'}
+                                    {isCreatingPayment ? 'Setting up payment…' : matchedStudents ? 'Is this you? 🔍' : multiMatchResults ? 'Select your record' : 'Welcome, Student! 👋'}
                                 </h2>
                                 <p className="text-sm text-gray-600">
                                     {!showAlternativeForm
-                                        ? 'Enter your exam number below to view your UBEAT results.'
+                                        ? multiMatchResults
+                                            ? `We found ${multiMatchResults.length} records matching your exam number — select the one that belongs to you.`
+                                            : 'Enter your exam number below to view your UBEAT results.'
                                         : isCreatingPayment
                                             ? 'Please wait while we prepare your payment link.'
                                             : matchedStudents
@@ -526,6 +586,79 @@ export default function UBEATLogin() {
                             </div>
 
                             {!showAlternativeForm ? (
+                                multiMatchResults ? (
+                                    <div className="space-y-3">
+                                        {error && (
+                                            <div className="bg-red-50 border border-red-200 rounded-lg p-3 flex items-start gap-2">
+                                                <svg className="w-4 h-4 text-red-600 shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" /></svg>
+                                                <p className="text-sm text-red-800 flex-1">{error}</p>
+                                                <button type="button" onClick={() => setError('')} className="text-red-400 hover:text-red-600 ml-1"><IoClose className="w-4 h-4" /></button>
+                                            </div>
+                                        )}
+                                        <motion.div
+                                            className="space-y-2"
+                                            variants={listVariants}
+                                            initial="hidden"
+                                            animate="show"
+                                        >
+                                            {multiMatchResults.map((match) => {
+                                                const isSelected = selectedStudentId === match._id
+                                                const isOther = isLoading && !isSelected
+                                                return (
+                                                    <motion.button
+                                                        key={match._id}
+                                                        variants={itemVariants}
+                                                        type="button"
+                                                        disabled={isLoading}
+                                                        onClick={() => handleMultiMatchSelect(match)}
+                                                        className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl border transition-all duration-150 text-left disabled:cursor-not-allowed ${
+                                                            isSelected
+                                                                ? 'border-green-400 bg-green-50 ring-2 ring-green-200'
+                                                                : isOther
+                                                                    ? 'border-gray-200 bg-gray-50 opacity-40 cursor-not-allowed'
+                                                                    : 'border-gray-200 bg-gray-50 hover:bg-green-50 hover:border-green-300 cursor-pointer'
+                                                        }`}
+                                                    >
+                                                        <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
+                                                            {isSelected
+                                                                ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
+                                                                : getInitials(match.studentName)
+                                                            }
+                                                        </div>
+                                                        <div className="flex-1 min-w-0">
+                                                            <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
+                                                                {match.studentName.toLowerCase()}
+                                                            </p>
+                                                            <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
+                                                                {match.examNo} &middot; {match.examYear}
+                                                            </p>
+                                                        </div>
+                                                        {isSelected
+                                                            ? <span className="w-4 h-4 border-2 border-green-400/40 border-t-green-500 rounded-full animate-spin flex-shrink-0 block" />
+                                                            : <IoChevronForward className="w-4 h-4 flex-shrink-0 text-gray-400" />
+                                                        }
+                                                    </motion.button>
+                                                )
+                                            })}
+                                        </motion.div>
+
+                                        <div className="flex items-center gap-3 pt-1">
+                                            <div className="flex-1 h-px bg-gray-100" />
+                                            <span className="text-xs text-gray-400">not you?</span>
+                                            <div className="flex-1 h-px bg-gray-100" />
+                                        </div>
+
+                                        <button
+                                            type="button"
+                                            disabled={isLoading}
+                                            onClick={() => { setMultiMatchResults(null); setSelectedStudentId(null); setError('') }}
+                                            className="w-full flex items-center justify-center gap-2 py-2.5 text-sm text-gray-500 hover:text-green-600 border border-gray-200 rounded-lg hover:border-green-300 transition-all duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                                        >
+                                            <IoSwapHorizontal className="w-4 h-4" />
+                                            None of these — search again
+                                        </button>
+                                    </div>
+                                ) : (
                                 <form onSubmit={handleLogin} className="space-y-5">
 
                                     {/* ── Recent Accounts ── */}
@@ -691,7 +824,7 @@ export default function UBEATLogin() {
                                         </button>
                                     </div>
                                 </form>
-                            ) : matchedStudents ? (
+                            )) : matchedStudents ? (
                                 /* ── Student Selection ── */
                                 <div className="space-y-3">
                                     {error && (

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { IoLogOut, IoDownload, IoPrint, IoSparkles, IoSwapHorizontal, IoTrophy } from 'react-icons/io5'
 import toast from 'react-hot-toast'
@@ -81,9 +81,10 @@ export default function UBEATDashboard() {
     }, [router])
 
     // Fetch student data using RTK Query
-    const queryArgs = examId
+    const queryArgs = useMemo(() => examId
         ? { _id: examId }
         : { examNo: examNo || '', year: examYear }
+    , [examId, examNo, examYear])
     const shouldSkip = !examId && (!examNo || !examYear)
     console.log('[UBEAT Dashboard] Query args:', queryArgs, 'skip:', shouldSkip, 'examId:', examId, 'examNo:', examNo, 'examYear:', examYear)
     const {

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -435,7 +435,7 @@ export default function UBEATDashboard() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNumber} />
+                <DetailsCheckBanner examNo={student.examNumber} studentName={student.studentName} school={student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-4 mb-6">

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -33,6 +33,7 @@ export default function UBEATDashboard() {
     const [isDownloading, setIsDownloading] = useState(false)
     const [examNo, setExamNo] = useState<string | null>(null)
     const [examYear, setExamYear] = useState<string>('')
+    const [examId, setExamId] = useState<string | null>(null)
 
     // Check for payment success from URL params
     useEffect(() => {
@@ -53,8 +54,16 @@ export default function UBEATDashboard() {
             SessionStore.get('student_exam_no'),
             SessionStore.get('selected_exam_type'),
             SessionStore.get('student_exam_year'),
-        ]).then(([storedExamNo, selectedExamType, storedExamYear]) => {
+            SessionStore.get('student_exam_id'),
+        ]).then(([storedExamNo, selectedExamType, storedExamYear, storedExamId]) => {
             if (cancelled) return
+
+            if (storedExamId) {
+                setExamId(storedExamId)
+                setExamYear(storedExamYear || new Date().getFullYear().toString())
+                return
+            }
+
             if (!storedExamNo || selectedExamType !== 'ubeat' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
                 toast.error('Invalid exam number. Please log in again.')
                 setTimeout(() => router.push('/result-checking/ubeat'), 0)
@@ -68,18 +77,22 @@ export default function UBEATDashboard() {
     }, [router])
 
     // Fetch student data using RTK Query
+    const queryArgs = examId
+        ? { _id: examId }
+        : { examNo: examNo || '', year: examYear }
     const {
         data: student,
         isLoading,
         isError,
         error
-    } = useGetUBEATResultQuery({ examNo: examNo || '', year: examYear }, {
-        skip: !examNo || !examYear,
+    } = useGetUBEATResultQuery(queryArgs, {
+        skip: !examId && (!examNo || !examYear),
     })
 
     const handleLogout = () => {
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         SessionStore.remove('selected_exam_type')
         toast.success('Logged out successfully')
         setTimeout(() => router.push('/result-checking/ubeat'), 0)
@@ -89,6 +102,7 @@ export default function UBEATDashboard() {
         SessionStore.remove('selected_exam_type')
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         toast('Returning to exam selection...', { icon: '🔄' })
         setTimeout(() => router.push('/result-checking'), 0)
     }

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -57,19 +57,23 @@ export default function UBEATDashboard() {
             SessionStore.get('student_exam_id'),
         ]).then(([storedExamNo, selectedExamType, storedExamYear, storedExamId]) => {
             if (cancelled) return
+            console.log('[UBEAT Dashboard] Session values:', { storedExamNo, selectedExamType, storedExamYear, storedExamId })
 
             if (storedExamId) {
+                console.log('[UBEAT Dashboard] Using examId:', storedExamId)
                 setExamId(storedExamId)
                 setExamYear(storedExamYear || new Date().getFullYear().toString())
                 return
             }
 
             if (!storedExamNo || selectedExamType !== 'ubeat' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
+                console.log('[UBEAT Dashboard] Invalid exam no, redirecting')
                 toast.error('Invalid exam number. Please log in again.')
                 setTimeout(() => router.push('/result-checking/ubeat'), 0)
                 return
             }
             const formattedExamNo = storedExamNo.replace(/\//g, '-')
+            console.log('[UBEAT Dashboard] Using examNo:', formattedExamNo, 'year:', storedExamYear)
             setExamNo(formattedExamNo)
             setExamYear(storedExamYear || new Date().getFullYear().toString())
         })
@@ -80,13 +84,15 @@ export default function UBEATDashboard() {
     const queryArgs = examId
         ? { _id: examId }
         : { examNo: examNo || '', year: examYear }
+    const shouldSkip = !examId && (!examNo || !examYear)
+    console.log('[UBEAT Dashboard] Query args:', queryArgs, 'skip:', shouldSkip, 'examId:', examId, 'examNo:', examNo, 'examYear:', examYear)
     const {
         data: student,
         isLoading,
         isError,
         error
     } = useGetUBEATResultQuery(queryArgs, {
-        skip: !examId && (!examNo || !examYear),
+        skip: shouldSkip,
     })
 
     const handleLogout = () => {

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -15,6 +15,7 @@ import { SessionStore } from '@/app/result-checking/utils/secureStorage'
 import celebrationData from "../components/CelebrationLolo.json"
 import { useMedia } from 'react-use'
 import PortalHeader from '../../../components/Portalheader'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 
 // Regex pattern for exam number validation (e.g., XX/000/000)
 const EXAM_NO_REGEX = /^[a-zA-Z]{2}\/\d{1,4}\/\d{1,4}(\(\d\))?$/
@@ -31,6 +32,7 @@ export default function UBEATDashboard() {
     const certificateRef = useRef<HTMLDivElement>(null)
     const [isDownloading, setIsDownloading] = useState(false)
     const [examNo, setExamNo] = useState<string | null>(null)
+    const [examYear, setExamYear] = useState<string>('')
 
     // Check for payment success from URL params
     useEffect(() => {
@@ -50,7 +52,8 @@ export default function UBEATDashboard() {
         Promise.all([
             SessionStore.get('student_exam_no'),
             SessionStore.get('selected_exam_type'),
-        ]).then(([storedExamNo, selectedExamType]) => {
+            SessionStore.get('student_exam_year'),
+        ]).then(([storedExamNo, selectedExamType, storedExamYear]) => {
             if (cancelled) return
             if (!storedExamNo || selectedExamType !== 'ubeat' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
                 toast.error('Invalid exam number. Please log in again.')
@@ -59,6 +62,7 @@ export default function UBEATDashboard() {
             }
             const formattedExamNo = storedExamNo.replace(/\//g, '-')
             setExamNo(formattedExamNo)
+            setExamYear(storedExamYear || new Date().getFullYear().toString())
         })
         return () => { cancelled = true }
     }, [router])
@@ -69,12 +73,13 @@ export default function UBEATDashboard() {
         isLoading,
         isError,
         error
-    } = useGetUBEATResultQuery(examNo || '', {
-        skip: !examNo,
+    } = useGetUBEATResultQuery({ examNo: examNo || '', year: examYear }, {
+        skip: !examNo || !examYear,
     })
 
     const handleLogout = () => {
         SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         SessionStore.remove('selected_exam_type')
         toast.success('Logged out successfully')
         setTimeout(() => router.push('/result-checking/ubeat'), 0)
@@ -82,6 +87,8 @@ export default function UBEATDashboard() {
 
     const handleChangeExam = () => {
         SessionStore.remove('selected_exam_type')
+        SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         toast('Returning to exam selection...', { icon: '🔄' })
         setTimeout(() => router.push('/result-checking'), 0)
     }
@@ -427,6 +434,8 @@ export default function UBEATDashboard() {
                         Academic Year {student.examYear || new Date().getFullYear()}
                     </p>
                 </div>
+
+                <DetailsCheckBanner examNo={student.examNumber} />
 
                 {/* Content Grid */}
                 <div className="space-y-4 mb-6">

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -435,7 +435,7 @@ export default function UBEATDashboard() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNumber} studentName={student.studentName} school={student.school} />
+                <DetailsCheckBanner examNo={student.examNumber} studentName={student.studentName} school={student.schoolName || student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-4 mb-6">

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -31,8 +31,6 @@ export default function UBEATDashboard() {
     const searchParams = useSearchParams()
     const certificateRef = useRef<HTMLDivElement>(null)
     const [isDownloading, setIsDownloading] = useState(false)
-    const [examNo, setExamNo] = useState<string | null>(null)
-    const [examYear, setExamYear] = useState<string>('')
     const [examId, setExamId] = useState<string | null>(null)
 
     // Check for payment success from URL params
@@ -47,53 +45,33 @@ export default function UBEATDashboard() {
         }
     }, [searchParams])
 
-    // Get exam number from encrypted localStorage
+    // Get exam id from session
     useEffect(() => {
         let cancelled = false
         Promise.all([
-            SessionStore.get('student_exam_no'),
-            SessionStore.get('selected_exam_type'),
-            SessionStore.get('student_exam_year'),
             SessionStore.get('student_exam_id'),
-        ]).then(([storedExamNo, selectedExamType, storedExamYear, storedExamId]) => {
+            SessionStore.get('selected_exam_type'),
+        ]).then(([storedExamId, selectedExamType]) => {
             if (cancelled) return
-            console.log('[UBEAT Dashboard] Session values:', { storedExamNo, selectedExamType, storedExamYear, storedExamId })
-
-            if (storedExamId) {
-                console.log('[UBEAT Dashboard] Using examId:', storedExamId)
-                setExamId(storedExamId)
-                setExamYear(storedExamYear || new Date().getFullYear().toString())
-                return
-            }
-
-            if (!storedExamNo || selectedExamType !== 'ubeat' || (!EXAM_NO_REGEX.test(storedExamNo) && !EXAM_NO_REGEX_02.test(storedExamNo) && !EXAM_NO_REGEX_03.test(storedExamNo))) {
-                console.log('[UBEAT Dashboard] Invalid exam no, redirecting')
-                toast.error('Invalid exam number. Please log in again.')
+            if (!storedExamId || selectedExamType !== 'ubeat') {
+                toast.error('Please log in again.')
                 setTimeout(() => router.push('/result-checking/ubeat'), 0)
                 return
             }
-            const formattedExamNo = storedExamNo.replace(/\//g, '-')
-            console.log('[UBEAT Dashboard] Using examNo:', formattedExamNo, 'year:', storedExamYear)
-            setExamNo(formattedExamNo)
-            setExamYear(storedExamYear || new Date().getFullYear().toString())
+            setExamId(storedExamId)
         })
         return () => { cancelled = true }
     }, [router])
 
     // Fetch student data using RTK Query
-    const queryArgs = useMemo(() => examId
-        ? { _id: examId }
-        : { examNo: examNo || '', year: examYear }
-    , [examId, examNo, examYear])
-    const shouldSkip = !examId && (!examNo || !examYear)
-    console.log('[UBEAT Dashboard] Query args:', queryArgs, 'skip:', shouldSkip, 'examId:', examId, 'examNo:', examNo, 'examYear:', examYear)
+    const queryArgs = useMemo(() => ({ _id: examId || '' }), [examId])
     const {
         data: student,
         isLoading,
         isError,
         error
     } = useGetUBEATResultQuery(queryArgs, {
-        skip: shouldSkip,
+        skip: !examId,
     })
 
     const handleLogout = () => {
@@ -222,7 +200,7 @@ export default function UBEATDashboard() {
     }
 
     // Show loading
-    if (isLoading || !examNo) {
+    if (isLoading || !examId) {
         return (
             <div className="min-h-screen bg-gradient-to-br from-green-50/30 via-white to-blue-50/30">
                 <header className="bg-white border-b border-gray-100 sticky top-0 z-50">

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -434,7 +434,7 @@ export default function UBEATDashboard() {
                     </p>
                 </div>
 
-                <DetailsCheckBanner examNo={student.examNumber} studentName={student.studentName} school={student.schoolName || student.school} />
+                <DetailsCheckBanner context="dashboard" examNo={student.examNumber} studentName={student.studentName} school={student.schoolName || student.school} />
 
                 {/* Content Grid */}
                 <div className="space-y-4 mb-6">

--- a/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
@@ -9,6 +9,7 @@ import { SessionStore } from '@/app/result-checking/utils/secureStorage'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useSetUbeatPaymentEmailMutation } from '@/app/result-checking/store/api/studentApi'
 import { isValidEmail } from '@/lib/utils'
+import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 
 interface PaywallProps {
     examNo: string
@@ -257,6 +258,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
             icon: '👋',
         })
         SessionStore.remove('student_exam_no')
+        SessionStore.remove('student_exam_year')
         SessionStore.remove('selected_exam_type')
         window.location.href = '/result-checking/ubeat'
     }
@@ -283,6 +285,8 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
 
                         {/* Content */}
                         <div className="px-8 py-6">
+
+                            <DetailsCheckBanner examNo={examNo} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
@@ -287,7 +287,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                         {/* Content */}
                         <div className="px-8 py-6">
 
-                            <DetailsCheckBanner examNo={examNo} studentName={studentName} school={school} />
+                            <DetailsCheckBanner context="paywall" examNo={examNo} studentName={studentName} school={school} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
@@ -259,6 +259,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
         })
         SessionStore.remove('student_exam_no')
         SessionStore.remove('student_exam_year')
+        SessionStore.remove('student_exam_id')
         SessionStore.remove('selected_exam_type')
         window.location.href = '/result-checking/ubeat'
     }

--- a/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
@@ -286,7 +286,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                         {/* Content */}
                         <div className="px-8 py-6">
 
-                            <DetailsCheckBanner examNo={examNo} />
+                            <DetailsCheckBanner examNo={examNo} studentName={studentName} school={school} />
 
                             {/* Student Info - Cleaner */}
                             <div className="mb-6 space-y-2.5">

--- a/src/app/result-checking/ubeat/payment/page.tsx
+++ b/src/app/result-checking/ubeat/payment/page.tsx
@@ -129,8 +129,9 @@ const storage = {
     async getReturnUrl(): Promise<string> {
         return (await SessionStore.get(STORAGE_KEYS.RETURN_URL)) ?? '/result-checking/ubeat/dashboard'
     },
-    async saveExamAccess(examNumber: string): Promise<void> {
+    async saveExamAccess(examNumber: string, year?: string): Promise<void> {
         await SessionStore.set(STORAGE_KEYS.EXAM_NO, examNumber)
+        if (year) await SessionStore.set('student_exam_year', year)
         await SessionStore.set(STORAGE_KEYS.EXAM_TYPE, 'ubeat')
     },
     clearPaymentData(): void {
@@ -316,7 +317,7 @@ function usePaymentVerification(
                         }
 
                         if (response.examNumber) {
-                            await storage.saveExamAccess(response.examNumber)
+                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''))
                             syncRecentAccount({
                                 examNo: response.examNumber,
                                 lastAccessed: Date.now(),

--- a/src/app/result-checking/ubeat/payment/page.tsx
+++ b/src/app/result-checking/ubeat/payment/page.tsx
@@ -34,9 +34,11 @@ import { isValidEmail } from '@/lib/utils'
 // ---------------------------------------------------------------------------
 
 interface RecentAccount {
+    _id?: string
     examNo: string
     studentName: string
     school: string
+    year?: string
     lastAccessed: number // Unix ms timestamp
 }
 
@@ -129,9 +131,10 @@ const storage = {
     async getReturnUrl(): Promise<string> {
         return (await SessionStore.get(STORAGE_KEYS.RETURN_URL)) ?? '/result-checking/ubeat/dashboard'
     },
-    async saveExamAccess(examNumber: string, year?: string): Promise<void> {
+    async saveExamAccess(examNumber: string, year?: string, id?: string): Promise<void> {
         await SessionStore.set(STORAGE_KEYS.EXAM_NO, examNumber)
         if (year) await SessionStore.set('student_exam_year', year)
+        if (id) await SessionStore.set('student_exam_id', id)
         await SessionStore.set(STORAGE_KEYS.EXAM_TYPE, 'ubeat')
     },
     clearPaymentData(): void {
@@ -317,9 +320,11 @@ function usePaymentVerification(
                         }
 
                         if (response.examNumber) {
-                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''))
+                            await storage.saveExamAccess(response.examNumber, String(response.examYear || ''), response._id)
                             syncRecentAccount({
+                                _id: response._id,
                                 examNo: response.examNumber,
+                                year: String(response.examYear || ''),
                                 lastAccessed: Date.now(),
                                 school: built.school || "N/A",
                                 studentName: built.studentName || "N/A"

--- a/src/app/result-checking/utils/api.ts
+++ b/src/app/result-checking/utils/api.ts
@@ -79,6 +79,7 @@ export interface CreatePaymentResponse {
 export interface VerifyPaymentSuccessResponse {
     reference: string
     paymentStatus: 'successful' | 'failed' | 'pending'
+    _id?: string
     studentName?: string
     school?: string
     paidAt?: string


### PR DESCRIPTION
## Summary

Two features for the result-checking flow (UBEAT & BECE):

### 1. Year Selection
- Login forms now require a year selected from a dropdown populated by `GET /ubeat/available-years`
- `year` is threaded through: login form → session (`student_exam_year`) → RTK queries (`?year=` query param) → payment callbacks → dashboard display
- Recent accounts stored in localStorage include the year

### 2. One-Time Details Check Banner
- Adds an amber info banner on paywalls reminding users to verify their details before paying
- Dismissed per exam number via `localStorage` — only shows once per user per exam
- "Reach Out to Support" button triggers the existing SupportWidget via `?contacting-support=true`

## Files Changed
10 files, +197 / -40

| File | Change |
|------|--------|
| `studentApi.ts` | Add `getAvailableYears`, add `year` param to result queries |
| UBEAT/BECE `PageContent.tsx` | Year dropdown, session storage, login flow |
| UBEAT/BECE dashboard `PageContent.tsx` / `page.tsx` | Read year from session, pass to query |
| UBEAT/BECE `payment/page.tsx` | Pass year to `saveExamAccess` |
| UBEAT/BECE `Paywall.tsx` | Clear year on logout, render DetailsCheckBanner |
| `DetailsCheckBanner.tsx` **(new)** | One-time dismissible banner component |