### PR TITLE
fix: gracefully handle missing fields, reorder inputs, remove retrieval modal

### DIFF
--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -250,7 +250,7 @@ export default function StudentLoginPage() {
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
         if (!isValidExamNo(examNo)) {
-            setError("Invalid format. Try: ok/977/2025/001")
+            setError("Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX")
             return
         }
         if (!year.trim() || year.trim().length !== 4) {
@@ -785,7 +785,7 @@ export default function StudentLoginPage() {
                                         ) : debouncedExamNo && !canProceed && debouncedExamNo.length > 0 ? (
                                             <p className="mt-2 text-sm text-yellow-600 flex items-center gap-1 animate-fadeIn-y">
                                                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" /></svg>
-                                                Invalid format (e.g., ok/977/2025/001)
+                                                Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX
                                             </p>
                                         ) : canProceed ? (
                                             <p className="mt-2 text-sm text-green-600 flex items-center gap-1 animate-fadeIn-y">
@@ -793,7 +793,7 @@ export default function StudentLoginPage() {
                                                 Ready to view your results!
                                             </p>
                                         ) : (
-                                            <p className="mt-2 text-xs text-gray-500">Format: xx/xxx/xxxx/xxx (e.g., ok/977/2025/001)</p>
+                                            <p className="mt-2 text-xs text-gray-500">Format: XX/XXX/XXX or XX/XXX/XXX/XXX</p>
                                         )}
                                     </div>
 

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -632,12 +632,12 @@ export default function StudentLoginPage() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.name)
+                                                                : getInitials(match.studentName)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.name.toLowerCase()}
+                                                                {match.studentName.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1070,7 +1070,7 @@ export default function StudentLoginPage() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name}
+                            studentName={confirmMatch.studentName}
                             school={confirmMatch.school?.schoolName}
                             onDismiss={() => {
                                 const match = confirmMatch

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -249,12 +249,12 @@ export default function StudentLoginPage() {
         setMultiMatchResults(null)
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
+        if (!year.trim() || year.trim().length !== 4) {
+            setError('Please select a valid exam year'); return
+        }
         if (!isValidExamNo(examNo)) {
             setError("Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX")
             return
-        }
-        if (!year.trim() || year.trim().length !== 4) {
-            setError('Please enter a valid exam year'); return
         }
 
         const rawExamNo = examNo.trim()
@@ -782,7 +782,7 @@ export default function StudentLoginPage() {
                                                 <svg className="w-4 h-4 flex-shrink-0 translate-y-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" /></svg>
                                                 <span>{error}, <Link className='inline text-blue-500' href={"?contacting-support=true"}>Get Help</Link></span>
                                             </p>
-                                        ) : debouncedExamNo && !canProceed && debouncedExamNo.length > 0 ? (
+                                        ) : debouncedExamNo && !isValidExamNo(debouncedExamNo) && debouncedExamNo.length > 0 ? (
                                             <p className="mt-2 text-sm text-yellow-600 flex items-center gap-1 animate-fadeIn-y">
                                                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" /></svg>
                                                 Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -102,7 +102,7 @@ export interface FindResultRequest {
 // Match returned by find-multiple-matches endpoint
 export interface MultiMatchResult {
     _id: string
-    name: string
+    studentName: string
     examNo: string
     examYear: number
     school?: {

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -625,12 +625,12 @@ export default function UBEATLogin() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.name)
+                                                                : getInitials(match.studentName)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.name.toLowerCase()}
+                                                                {match.studentName.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1063,7 +1063,7 @@ export default function UBEATLogin() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name}
+                            studentName={confirmMatch.studentName}
                             school={confirmMatch.school?.schoolName}
                             onDismiss={() => {
                                 const match = confirmMatch

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -249,7 +249,7 @@ export default function UBEATLogin() {
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
         if (!isValidExamNo(examNo)) {
-            setError("Invalid format. Try: ok/977/2025/001")
+            setError("Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX")
             return
         }
         if (!year.trim() || year.trim().length !== 4) {
@@ -778,7 +778,7 @@ export default function UBEATLogin() {
                                         ) : debouncedExamNo && !canProceed && debouncedExamNo.length > 0 ? (
                                             <p className="mt-2 text-sm text-yellow-600 flex items-center gap-1 animate-fadeIn-y">
                                                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" /></svg>
-                                                Invalid format (e.g., ok/977/2025/001)
+                                                Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX
                                             </p>
                                         ) : canProceed ? (
                                             <p className="mt-2 text-sm text-green-600 flex items-center gap-1 animate-fadeIn-y">
@@ -786,7 +786,7 @@ export default function UBEATLogin() {
                                                 Ready to view your results!
                                             </p>
                                         ) : (
-                                            <p className="mt-2 text-xs text-gray-500">Format: xx/xxx/xxxx/xxx (e.g., ok/977/2025/001)</p>
+                                            <p className="mt-2 text-xs text-gray-500">Format: XX/XXX/XXX or XX/XXX/XXX/XXX</p>
                                         )}
                                     </div>
 

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -248,12 +248,12 @@ export default function UBEATLogin() {
         setMultiMatchResults(null)
 
         if (!examNo.trim()) { setError('Please enter your exam number to continue'); return }
+        if (!year.trim() || year.trim().length !== 4) {
+            setError('Please select a valid exam year'); return
+        }
         if (!isValidExamNo(examNo)) {
             setError("Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX")
             return
-        }
-        if (!year.trim() || year.trim().length !== 4) {
-            setError('Please enter a valid exam year'); return
         }
 
         const rawExamNo = examNo.trim()
@@ -775,7 +775,7 @@ export default function UBEATLogin() {
                                                 <svg className="w-4 h-4 flex-shrink-0 translate-y-0.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" /></svg>
                                                 <span>{error}, <Link className='inline text-blue-500' href={"?contacting-support=true"}>Get Help</Link></span>
                                             </p>
-                                        ) : debouncedExamNo && !canProceed && debouncedExamNo.length > 0 ? (
+                                        ) : debouncedExamNo && !isValidExamNo(debouncedExamNo) && debouncedExamNo.length > 0 ? (
                                             <p className="mt-2 text-sm text-yellow-600 flex items-center gap-1 animate-fadeIn-y">
                                                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" /></svg>
                                                 Supported formats: XX/XXX/XXX or XX/XXX/XXX/XXX


### PR DESCRIPTION
## Summary
- Gracefully handle missing fields across UBET/BECE dashboards and paywalls to prevent page crashes in production
- Guard all `subjects.map/filter/reduce/length` calls with `(student.subjects || [])`
- Guard all `name/studentName/school/lga.toLowerCase()` calls with `(field || '')`
- Fix BECE paywall `school.toLowerCase()` (was missing optional chaining)
- Swap input order: exam year before exam number
- Remove WhatsApp modal from retrieval screens (insufficient info at that point)