### PR TITLE
fix: gracefully handle missing fields, reorder inputs, safe getInitials

### DIFF
--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -742,6 +742,19 @@ export default function StudentLoginPage() {
                                         )}
                                     </AnimatePresence>
 
+                                    {/* Exam Year */}
+                                    <div className="group relative">
+                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
+                                            Exam Year <span className="text-red-500">*</span>
+                                        </label>
+                                        <CustomDropdown
+                                            options={availableYearOptions}
+                                            value={year}
+                                            onChange={value => { setYear(value); setError('') }}
+                                            placeholder="Select exam year"
+                                        />
+                                    </div>
+
                                     {/* ── Exam Number Input ── */}
                                     <div className="group">
                                         <label htmlFor="examNo" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
@@ -795,19 +808,6 @@ export default function StudentLoginPage() {
                                         ) : (
                                             <p className="mt-2 text-xs text-gray-500">Format: XX/XXX/XXX or XX/XXX/XXX/XXX</p>
                                         )}
-                                    </div>
-
-                                    {/* Exam Year */}
-                                    <div className="group relative">
-                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
-                                            Exam Year <span className="text-red-500">*</span>
-                                        </label>
-                                        <CustomDropdown
-                                            options={availableYearOptions}
-                                            value={year}
-                                            onChange={value => { setYear(value); setError('') }}
-                                            placeholder="Select exam year"
-                                        />
                                     </div>
 
                                     {/* Submit */}

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -272,6 +272,7 @@ export default function StudentLoginPage() {
             }
 
             setMultiMatchResults(matches)
+            console.log('[BECE Login] multiMatchResults:', JSON.stringify(matches, null, 2))
             if (matches.length === 1) {
                 setConfirmMatch(matches[0])
             }
@@ -636,12 +637,12 @@ export default function StudentLoginPage() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.name)
+                                                                 : getInitials(match.name || match.studentName)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {(match.name || 'Unknown').toLowerCase()}
+                                                                {(match.name || match.studentName || 'Unknown').toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1074,7 +1075,7 @@ export default function StudentLoginPage() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name}
+                            studentName={confirmMatch.name || confirmMatch.studentName}
                             school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
                             examYear={String(confirmMatch.examYear || '')}
                             onDismiss={() => {

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -271,6 +271,9 @@ export default function StudentLoginPage() {
             }
 
             setMultiMatchResults(matches)
+            if (matches.length === 1) {
+                setConfirmMatch(matches[0])
+            }
             toast.dismiss("finding-matches")
             toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
@@ -632,12 +635,12 @@ export default function StudentLoginPage() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.studentName)
+                                                                : getInitials(match.name)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.studentName.toLowerCase()}
+                                                                {match.name.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1070,8 +1073,9 @@ export default function StudentLoginPage() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.studentName}
-                            school={confirmMatch.school?.schoolName}
+                            studentName={confirmMatch.name}
+                            school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
+                            examYear={String(confirmMatch.examYear || '')}
                             onDismiss={() => {
                                 const match = confirmMatch
                                 setConfirmMatch(null)

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -52,7 +52,8 @@ function isValidExamNo(val: string) {
     return EXAM_NO_REGEX.test(val) || EXAM_NO_REGEX_02.test(val) || EXAM_NO_REGEX_03.test(val)
 }
 
-function getInitials(name: string) {
+function getInitials(name: string | undefined | null) {
+    if (!name) return '?'
     return name
         .split(' ')
         .filter(Boolean)
@@ -640,7 +641,7 @@ export default function StudentLoginPage() {
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.name.toLowerCase()}
+                                                                {(match.name || 'Unknown').toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -10,7 +10,6 @@ import Image from 'next/image'
 import { useDebounce } from '../../../portal/utils/hooks/useDebounce'
 import Link from 'next/link'
 import { useLazyGetBECEResultQuery, useFindBECEResultMutation, useCreateBECEPaymentMutation, useGetAvailableYearsQuery, useFindBECEMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
-import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
@@ -179,7 +178,6 @@ export default function StudentLoginPage() {
 
     const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
     const [isFindingMatches, setIsFindingMatches] = useState(false)
-    const [confirmMatch, setConfirmMatch] = useState<MultiMatchResult | null>(null)
 
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
@@ -273,9 +271,6 @@ export default function StudentLoginPage() {
 
             setMultiMatchResults(matches)
             console.log('[BECE Login] multiMatchResults:', JSON.stringify(matches, null, 2))
-            if (matches.length === 1) {
-                setConfirmMatch(matches[0])
-            }
             toast.dismiss("finding-matches")
             toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
@@ -364,7 +359,7 @@ export default function StudentLoginPage() {
     const handleMultiMatchSelect = async (match: MultiMatchResult) => {
         setSelectedStudentId(match._id)
         setError('')
-        setConfirmMatch(match)
+        await proceedWithResult({ _id: match._id, examNo: examNo, year })
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -1069,21 +1064,6 @@ export default function StudentLoginPage() {
                                 <strong>📝 Note:</strong> Use your official BECE exam number from your school.
                             </p>
                         </div>
-                    )}
-
-                    {confirmMatch && (
-                        <DetailsCheckBanner
-                            context="retrieval"
-                            examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name || confirmMatch.studentName}
-                            school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
-                            examYear={String(confirmMatch.examYear || '')}
-                            onDismiss={() => {
-                                const match = confirmMatch
-                                setConfirmMatch(null)
-                                proceedWithResult({ _id: match._id, examNo: examNo, year })
-                            }}
-                        />
                     )}
 
                     <div className="mt-6 text-center">

--- a/src/app/result-checking/bece/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/bece/dashboard/components/Paywall.tsx
@@ -291,13 +291,13 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                                 <div className="flex justify-between text-sm">
                                     <span className="text-gray-500">Name</span>
                                     <span className="font-medium text-gray-900 capitalize">
-                                        {studentName.toLowerCase()}
+                                        {(studentName || '').toLowerCase()}
                                     </span>
                                 </div>
                                 <div className="flex justify-between text-sm">
                                     <span className="text-gray-500">School</span>
                                     <span className="font-medium text-gray-900 capitalize text-right max-w-[60%]">
-                                        {school.toLowerCase()}
+                                        {(school || '').toLowerCase()}
                                     </span>
                                 </div>
                                 <div className="flex justify-between text-sm">

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default function StudentDashboardPage() {
 
     const calculateAverage = () => {
         if (!student) return '0'
-        const scores = student.subjects.map(s => s.exam)
+        const scores = (student.subjects || []).map(s => s.exam)
         const total = scores.reduce((sum, score) => sum + score, 0)
         return (total / scores.length).toFixed(1)
     }
@@ -72,7 +72,7 @@ export default function StudentDashboardPage() {
     // Calculate credits (C4, C5, C6 grades)
     const calculateCredits = () => {
         if (!student) return 0
-        return student.subjects.filter(s => {
+        return (student.subjects || []).filter(s => {
             const grade = s.grade || calculateGradeFromScore(s.exam)
             return ['C4', 'C5', 'C6'].includes(grade)
         }).length
@@ -86,12 +86,12 @@ export default function StudentDashboardPage() {
             'D7': 7, 'E8': 8, 'F9': 9
         }
 
-        const totalPoints = student.subjects.reduce((sum, subject) => {
+        const totalPoints = (student.subjects || []).reduce((sum, subject) => {
             const grade = subject.grade || calculateGradeFromScore(subject.exam)
             return sum + (gradePoints[grade] || 9)
         }, 0)
 
-        const average = totalPoints / student.subjects.length
+        const average = totalPoints / (student.subjects || []).length
         if (average <= 1.5) return 'Distinction'
         if (average <= 2.5) return 'Credit'
         if (average <= 4.5) return 'Pass'
@@ -179,8 +179,8 @@ export default function StudentDashboardPage() {
                     schoolName: student.schoolName || student.school,
                     lga: student.lga,
                     year: certYear,
-                    subjectCount: student.subjects.length,
-                    courses: student.subjects.map((s) => ({
+                    subjectCount: (student.subjects || []).length,
+                    courses: (student.subjects || []).map((s) => ({
                         subject: s.name ?? '—',
                         grade: (s.grade != null && String(s.grade).trim() !== '') ? String(s.grade).trim() : calculateGradeFromScore(s.exam ?? 0),
                     })),
@@ -406,7 +406,7 @@ export default function StudentDashboardPage() {
                                 </div>
                                 <div>
                                     <h2 className="sm:text-2xl text-lg font-bold text-gray-900 mb-2">
-                                        Congratulations, <span className="capitalize">{student.name.toLowerCase()}</span>!
+                                        Congratulations, <span className="capitalize">{(student.name || '').toLowerCase()}</span>!
                                     </h2>
                                     <p className="sm:text-base text-sm text-gray-700 mb-1">
                                         You&apos;ve worked hard and here are your BECE results
@@ -461,7 +461,7 @@ export default function StudentDashboardPage() {
                             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                                 <div className="text-center">
                                     <p className="text-2xl font-semibold text-gray-900 mb-1">
-                                        {student.subjects.length}
+                                        {(student.subjects || []).length}
                                     </p>
                                     <p className="text-xs text-gray-500">Subjects</p>
                                 </div>
@@ -514,7 +514,7 @@ export default function StudentDashboardPage() {
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-gray-100">
-                                    {student.subjects.map((subject, index) => {
+                                    {(student.subjects || []).map((subject, index) => {
                                         const calculatedGrade = calculateGradeFromScore(subject.exam)
                                         return (
                                             <tr key={index} className="hover:bg-gray-50 transition-colors">
@@ -635,7 +635,7 @@ export default function StudentDashboardPage() {
                     <div className="grid grid-cols-2 gap-4">
                         <div>
                             <p className="text-sm text-gray-600 mb-1">Full Name</p>
-                            <p className="text-base font-semibold text-gray-900 capitalize">{student.name.toLowerCase()}</p>
+                            <p className="text-base font-semibold text-gray-900 capitalize">{(student.name || '').toLowerCase()}</p>
                         </div>
                         <div>
                             <p className="text-sm text-gray-600 mb-1">Exam Number</p>
@@ -643,11 +643,11 @@ export default function StudentDashboardPage() {
                         </div>
                         <div>
                             <p className="text-sm text-gray-600 mb-1">School</p>
-                            <p className="text-base font-semibold text-gray-900 capitalize">{student?.school.toLowerCase()}</p>
+                            <p className="text-base font-semibold text-gray-900 capitalize">{(student?.school || '').toLowerCase()}</p>
                         </div>
                         <div>
                             <p className="text-sm text-gray-600 mb-1">LGA</p>
-                            <p className="text-base font-semibold text-gray-900 capitalize">{student.lga.toLowerCase()}</p>
+                            <p className="text-base font-semibold text-gray-900 capitalize">{(student.lga || '').toLowerCase()}</p>
                         </div>
                     </div>
                 </div>
@@ -657,7 +657,7 @@ export default function StudentDashboardPage() {
                 <div className="bg-green-50 rounded-2xl p-6 mb-6 border border-green-200">
                     <div className="grid grid-cols-4 gap-4 text-center">
                         <div>
-                            <p className="text-2xl font-bold text-gray-900">{student.subjects.length}</p>
+                            <p className="text-2xl font-bold text-gray-900">{(student.subjects || []).length}</p>
                             <p className="text-sm text-gray-600">Subjects</p>
                         </div>
                         <div>
@@ -687,7 +687,7 @@ export default function StudentDashboardPage() {
                             </tr>
                         </thead>
                         <tbody>
-                            {student.subjects.map((subject, index) => {
+                            {(student.subjects || []).map((subject, index) => {
                                 const calculatedGrade = calculateGradeFromScore(subject.exam)
                                 return (
                                     <tr key={index}>

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -15,13 +15,14 @@ interface DetailsCheckBannerProps {
   examNo: string
   studentName?: string
   school?: string
+  examYear?: string
   context: 'paywall' | 'dashboard' | 'retrieval'
   onDismiss?: () => void
 }
 
-export default function DetailsCheckBanner({ examNo, studentName, school, context, onDismiss }: DetailsCheckBannerProps) {
+export default function DetailsCheckBanner({ examNo, studentName, school, examYear: examYearProp, context, onDismiss }: DetailsCheckBannerProps) {
   const [open, setOpen] = useState(false)
-  const [examYear, setExamYear] = useState('')
+  const [examYear, setExamYear] = useState(examYearProp || '')
   const [message, setMessage] = useState('')
   const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || '2348123456789'
 
@@ -29,11 +30,17 @@ export default function DetailsCheckBanner({ examNo, studentName, school, contex
     const key = `details_check_dismissed_${context}_${examNo}`
     const stored = localStorage.getItem(key)
     if (!stored) setOpen(true)
-
-    SessionStore.get('student_exam_year').then((year) => {
-      if (year) setExamYear(year)
-    })
   }, [examNo, context])
+
+  useEffect(() => {
+    if (examYearProp) {
+      setExamYear(examYearProp)
+    } else {
+      SessionStore.get('student_exam_year').then((year) => {
+        if (year) setExamYear(year)
+      })
+    }
+  }, [examYearProp])
 
   const handleDismiss = () => {
     const key = `details_check_dismissed_${context}_${examNo}`
@@ -52,7 +59,7 @@ export default function DetailsCheckBanner({ examNo, studentName, school, contex
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle className="text-lg">Check Your Details</DialogTitle>
           <DialogDescription>
@@ -101,15 +108,15 @@ export default function DetailsCheckBanner({ examNo, studentName, school, contex
         <DialogFooter className="sm:justify-between gap-3">
           <button
             onClick={handleDismiss}
-            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
+            className="px-4 py-2.5 flex-1 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors"
           >
-            Looks good, dismiss
+            Proceed to Dashboard
           </button>
           <a
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm"
+            className="inline-flex justify-center items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm"
           >
             <IoLogoWhatsapp className="w-4 h-4" />
             Reach Out via WhatsApp

--- a/src/app/result-checking/components/DetailsCheckBanner.tsx
+++ b/src/app/result-checking/components/DetailsCheckBanner.tsx
@@ -116,7 +116,7 @@ export default function DetailsCheckBanner({ examNo, studentName, school, examYe
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex justify-center items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm"
+            className="inline-flex flex-1 justify-center items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm"
           >
             <IoLogoWhatsapp className="w-4 h-4" />
             Reach Out via WhatsApp

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -102,7 +102,7 @@ export interface FindResultRequest {
 // Match returned by find-multiple-matches endpoint
 export interface MultiMatchResult {
     _id: string
-    studentName: string
+    name: string
     examNo: string
     examYear: number
     school?: {

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -103,6 +103,7 @@ export interface FindResultRequest {
 export interface MultiMatchResult {
     _id: string
     name?: string
+    studentName?: string
     examNo: string
     examYear: number
     school?: {

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -102,7 +102,7 @@ export interface FindResultRequest {
 // Match returned by find-multiple-matches endpoint
 export interface MultiMatchResult {
     _id: string
-    name: string
+    name?: string
     examNo: string
     examYear: number
     school?: {

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -271,6 +271,7 @@ export default function UBEATLogin() {
             }
 
             setMultiMatchResults(matches)
+            console.log('[UBEAT Login] multiMatchResults:', JSON.stringify(matches, null, 2))
             if (matches.length === 1) {
                 setConfirmMatch(matches[0])
             }
@@ -629,12 +630,12 @@ export default function UBEATLogin() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.name)
+                                                                 : getInitials(match.name || match.studentName)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {(match.name || 'Unknown').toLowerCase()}
+                                                                {(match.name || match.studentName || 'Unknown').toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1067,7 +1068,7 @@ export default function UBEATLogin() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name}
+                            studentName={confirmMatch.name || confirmMatch.studentName}
                             school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
                             examYear={String(confirmMatch.examYear || '')}
                             onDismiss={() => {

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -735,6 +735,19 @@ export default function UBEATLogin() {
                                         )}
                                     </AnimatePresence>
 
+                                    {/* Exam Year */}
+                                    <div className="group relative">
+                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
+                                            Exam Year <span className="text-red-500">*</span>
+                                        </label>
+                                        <CustomDropdown
+                                            options={availableYearOptions}
+                                            value={year}
+                                            onChange={value => { setYear(value); setError('') }}
+                                            placeholder="Select exam year"
+                                        />
+                                    </div>
+
                                     {/* ── Exam Number Input ── */}
                                     <div className="group">
                                         <label htmlFor="examNo" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
@@ -788,19 +801,6 @@ export default function UBEATLogin() {
                                         ) : (
                                             <p className="mt-2 text-xs text-gray-500">Format: XX/XXX/XXX or XX/XXX/XXX/XXX</p>
                                         )}
-                                    </div>
-
-                                    {/* Exam Year */}
-                                    <div className="group relative">
-                                        <label htmlFor="loginExamYear" className="block text-sm font-medium text-gray-700 mb-2 group-hover:text-green-600 transition-colors duration-200">
-                                            Exam Year <span className="text-red-500">*</span>
-                                        </label>
-                                        <CustomDropdown
-                                            options={availableYearOptions}
-                                            value={year}
-                                            onChange={value => { setYear(value); setError('') }}
-                                            placeholder="Select exam year"
-                                        />
                                     </div>
 
                                     {/* Submit */}

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -270,6 +270,9 @@ export default function UBEATLogin() {
             }
 
             setMultiMatchResults(matches)
+            if (matches.length === 1) {
+                setConfirmMatch(matches[0])
+            }
             toast.dismiss("finding-matches")
             toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
@@ -625,12 +628,12 @@ export default function UBEATLogin() {
                                                         <div className="flex-shrink-0 w-9 h-9 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 flex items-center justify-center text-white text-xs font-bold shadow-sm">
                                                             {isSelected
                                                                 ? <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin block" />
-                                                                : getInitials(match.studentName)
+                                                                : getInitials(match.name)
                                                             }
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.studentName.toLowerCase()}
+                                                                {match.name.toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}
@@ -1063,8 +1066,9 @@ export default function UBEATLogin() {
                         <DetailsCheckBanner
                             context="retrieval"
                             examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.studentName}
-                            school={confirmMatch.school?.schoolName}
+                            studentName={confirmMatch.name}
+                            school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
+                            examYear={String(confirmMatch.examYear || '')}
                             onDismiss={() => {
                                 const match = confirmMatch
                                 setConfirmMatch(null)

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -49,7 +49,8 @@ function isValidExamNo(val: string) {
     return EXAM_NO_REGEX.test(val) || EXAM_NO_REGEX_02.test(val) || EXAM_NO_REGEX_03.test(val)
 }
 
-function getInitials(name: string) {
+function getInitials(name: string | undefined | null) {
+    if (!name) return '?'
     return name
         .split(' ')
         .filter(Boolean)
@@ -633,7 +634,7 @@ export default function UBEATLogin() {
                                                         </div>
                                                         <div className="flex-1 min-w-0">
                                                             <p className={`text-sm font-semibold truncate capitalize ${isSelected ? 'text-green-700' : 'text-gray-900'}`}>
-                                                                {match.name.toLowerCase()}
+                                                                {(match.name || 'Unknown').toLowerCase()}
                                                             </p>
                                                             <p className="text-xs text-gray-400 font-mono uppercase truncate mt-0.5">
                                                                 {match.examNo} &middot; {match.examYear}

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -11,7 +11,6 @@ import Link from 'next/link'
 import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
 import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
 import { useLazyGetUBEATResultQuery, useFindUBEATResultMutation, useCreateUBEATPaymentMutation, useGetAvailableYearsQuery, useFindMultipleMatchesMutation, type FindResultMatch, type MultiMatchResult } from '../../store/api/studentApi'
-import DetailsCheckBanner from '@/app/result-checking/components/DetailsCheckBanner'
 import { AnimatePresence, motion, Variants } from 'framer-motion'
 import { SessionStore, useSecureSessionStorage } from '@/app/result-checking/utils/secureStorage'
 import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
@@ -177,7 +176,6 @@ export default function UBEATLogin() {
 
     const [multiMatchResults, setMultiMatchResults] = useState<MultiMatchResult[] | null>(null)
     const [isFindingMatches, setIsFindingMatches] = useState(false)
-    const [confirmMatch, setConfirmMatch] = useState<MultiMatchResult | null>(null)
 
     // ── Recent accounts (persisted, encrypted) ───────────────────────────────
     const [recentAccounts, setRecentAccounts] = useSecureSessionStorage<RecentAccount[]>(
@@ -272,9 +270,6 @@ export default function UBEATLogin() {
 
             setMultiMatchResults(matches)
             console.log('[UBEAT Login] multiMatchResults:', JSON.stringify(matches, null, 2))
-            if (matches.length === 1) {
-                setConfirmMatch(matches[0])
-            }
             toast.dismiss("finding-matches")
             toast.success(`Found ${matches.length} record${matches.length !== 1 ? 's' : ''} — please select yours.`)
         } catch (error: unknown) {
@@ -363,7 +358,7 @@ export default function UBEATLogin() {
     const handleMultiMatchSelect = async (match: MultiMatchResult) => {
         setSelectedStudentId(match._id)
         setError('')
-        setConfirmMatch(match)
+        await proceedWithResult({ _id: match._id, examNo: examNo, year })
     }
 
     const handleSelectRecent = async (selectedAccount: RecentAccount) => {
@@ -1062,21 +1057,6 @@ export default function UBEATLogin() {
                                 <strong>📝 Note:</strong> Use your official UBEAT exam number from your school.
                             </p>
                         </div>
-                    )}
-
-                    {confirmMatch && (
-                        <DetailsCheckBanner
-                            context="retrieval"
-                            examNo={confirmMatch.examNo}
-                            studentName={confirmMatch.name || confirmMatch.studentName}
-                            school={confirmMatch.school?.schoolName || confirmMatch.school?.lga || ''}
-                            examYear={String(confirmMatch.examYear || '')}
-                            onDismiss={() => {
-                                const match = confirmMatch
-                                setConfirmMatch(null)
-                                proceedWithResult({ _id: match._id, examNo: examNo, year })
-                            }}
-                        />
                     )}
 
                     <div className="mt-6 text-center">

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -399,7 +399,7 @@ export default function UBEATDashboard() {
                                 </div>
                                 <div>
                                     <h2 className="sm:text-2xl text-lg font-bold text-gray-900 mb-2">
-                                        Congratulations, <span className="capitalize">{student.studentName.toLowerCase()}</span>!
+                                        Congratulations, <span className="capitalize">{(student.studentName || '').toLowerCase()}</span>!
                                     </h2>
                                     <p className="sm:text-base text-sm text-gray-700 mb-1">
                                         You&apos;ve worked hard and here are your UBEAT results
@@ -448,7 +448,7 @@ export default function UBEATDashboard() {
                                 <div>
                                     <p className="text-xs font-medium text-gray-500 mb-1.5">Full Name</p>
                                     <p className="text-sm font-medium text-gray-900 capitalize">
-                                        {student.studentName.toLowerCase()}
+                                        {(student.studentName || '').toLowerCase()}
                                     </p>
                                 </div>
                                 <div>
@@ -673,7 +673,7 @@ export default function UBEATDashboard() {
                     <div className="grid grid-cols-2 gap-4">
                         <div>
                             <p className="text-sm text-gray-600 mb-1">Full Name</p>
-                            <p className="text-base font-semibold text-gray-900 capitalize">{student.studentName.toLowerCase()}</p>
+                            <p className="text-base font-semibold text-gray-900 capitalize">{(student.studentName || '').toLowerCase()}</p>
                         </div>
                         <div>
                             <p className="text-sm text-gray-600 mb-1">Exam Number</p>

--- a/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/Paywall.tsx
@@ -294,7 +294,7 @@ export default function Paywall({ examNo, studentName, school }: PaywallProps) {
                                 <div className="flex justify-between text-sm">
                                     <span className="text-gray-500">Name</span>
                                     <span className="font-medium text-gray-900 capitalize">
-                                        {studentName.toLowerCase()}
+                                        {(studentName || '').toLowerCase()}
                                     </span>
                                 </div>
                                 <div className="flex justify-between text-sm">


### PR DESCRIPTION
## Summary
- Guard all `subjects.map/filter/reduce/length` with `(student.subjects || [])` to prevent crashes on missing data
- Guard all `name/studentName/school/lga.toLowerCase()` with `(field || '')` fallback
- Swap input order: exam year before exam number on both UBEAT and BECE login forms
- Remove WhatsApp confirmation modal from retrieval screens (insufficient info at that point)
- Safe `getInitials` — handles undefined/null (returns `?`)
- Handle both `name` and `studentName` fields from API in `MultiMatchResult`
- Pass `examYear` prop to `DetailsCheckBanner` instead of relying solely on session storage