### PR TITLE
feat: bulk downloads for BECE & UBEAT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent Git Guide
+
+## Identity (global)
+- Name: `Developer`
+- Email: `developer@example.com`
+
+## Remote
+- Origin: `git@github.com:IDCLofficial/ministry-of-primary-education.git`
+- Auth: SSH key
+
+## Workflow
+
+### Branch strategy
+- **`main`** — production. Never commit directly.
+- **`fixes`** — upstream staging branch.
+- Feature branches branch off `main` or from other feature branches:
+  - `fixes-result-checking-updates`
+  - `signatures-and-constants` (current)
+- Always push your current feature branch, not `main`.
+
+### Before committing
+1. `git status` — see what's changed
+2. `git diff --stat` — overview of changes
+3. `git diff` — review actual diffs
+4. Never stage secrets, `.env`, `node_modules/`, large build artifacts
+
+### Commit style
+- Use conventional commits: `type: short description`
+- Types: `feat:`, `fix:`, `refactor:`, `revert:`, `docs:`, `chore:`
+- All lowercase, no period at end
+- Present tense, imperative mood
+- Examples: `fix: handle missing fields gracefully`, `feat: add download button to student info card`
+
+### Commit & push
+```bash
+git add <files>
+git commit -m "type: description"
+git push origin <current-branch>
+```
+
+### Amending (only if commit hasn't been pushed yet)
+```bash
+git add <files>
+git commit --amend --no-edit
+```
+
+## Project conventions
+- `npm run lint` / `npx tsc --noEmit` to verify before pushing
+- No git hooks are active (all `.sample` files only)
+- `.gitignore` covers: `node_modules/`, `.next/`, `out/`, `build/`, `coverage/`, `.DS_Store`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.0",
         "jspdf-autotable": "^5.0.7",
+        "jszip": "^3.10.1",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.577.0",
         "next": "^15.5.12",
@@ -5376,6 +5377,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -7828,6 +7835,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
@@ -8648,6 +8661,24 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8697,6 +8728,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -10220,6 +10260,12 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10707,6 +10753,27 @@
         "react-dom": "*"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -11018,6 +11085,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -11217,6 +11290,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11607,6 +11686,15 @@
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.0",
     "jspdf-autotable": "^5.0.7",
+    "jszip": "^3.10.1",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.577.0",
     "next": "^15.5.12",

--- a/src/app/exam-portal/dashboard/schools/[schoolId]/ubeat/utils/certificateGenerator.ts
+++ b/src/app/exam-portal/dashboard/schools/[schoolId]/ubeat/utils/certificateGenerator.ts
@@ -513,8 +513,9 @@ export const generateUBEATCertificate = async (
     data: CertificateData,
     certificateType: 'pass' | 'credit' | 'distinction' = 'pass',
     customFields?: CertificateFieldsConfig,
-    customFonts?: CustomFont[]
-): Promise<void> => {
+    customFonts?: CustomFont[],
+    returnBlob?: boolean
+): Promise<void | Blob> => {
     const { student, schoolName } = data;
     
     // Load custom fonts if provided, otherwise load default Handlee font
@@ -787,18 +788,22 @@ export const generateUBEATCertificate = async (
                     return
                 }
 
-                const url  = URL.createObjectURL(blob)
-                const link = document.createElement('a')
-                const filename = `UBEAT_Certificate_${student.examNumber.replace(/\//g, '_')}.png`
+                if (returnBlob) {
+                    resolve(blob)
+                } else {
+                    const url  = URL.createObjectURL(blob)
+                    const link = document.createElement('a')
+                    const filename = `UBEAT_Certificate_${student.examNumber.replace(/\//g, '_')}.png`
 
-                link.href     = url
-                link.download = filename
-                document.body.appendChild(link)
-                link.click()
-                document.body.removeChild(link)
+                    link.href     = url
+                    link.download = filename
+                    document.body.appendChild(link)
+                    link.click()
+                    document.body.removeChild(link)
 
-                URL.revokeObjectURL(url)
-                resolve()
+                    URL.revokeObjectURL(url)
+                    resolve()
+                }
             }, 'image/png')
         }
 

--- a/src/app/portal/utils/constants/Api.const.ts
+++ b/src/app/portal/utils/constants/Api.const.ts
@@ -13,8 +13,67 @@ export const endpoints = {
     CREATE_PASSWORD: '/auth/createPassword',
     PROFILE: '/auth/profile',
     GET_STUDENTS_BY_SCHOOL: (examType: ExamTypeEnum, schoolId: string)=>`/students/${examType}/${schoolId}`,
+    /**
+     * Bulk Downloads (agent) — list every student in a school cohort for bulk
+     * payment/selection. The exam type is in the URL; pagination and cohort
+     * filters live in the POST body, status filtering is a query param.
+     *
+     * URL:     POST /{examType}/students/by-school?paymentStatus=paid|unpaid
+     * Body:    { year, lga, schoolId, page, limit }
+     * Response: {
+     *   data: BulkStudentListItem[],
+     *   pagination: { total, page, limit, totalPages, hasNextPage, hasPreviousPage }
+     * }
+     */
+    GET_BULK_STUDENTS_BY_SCHOOL: (examType: ExamTypeEnum) => `/${examType === "BECE"? "bece-student": examType}/students/by-school`,
     CREATE_STUDENT_PAYMENT: '/student-payments/school',
     VERIFY_PAYMENT: '/student-payments/verify',
+    /**
+     * Bulk Payments (agent) — initiate a single Paystack transaction that
+     * covers N selected students in one go. The agent's selected `studentIds`
+     * are persisted in the transaction metadata; on verification, the
+     * backend marks every saved student as paid.
+     *
+     * URL:      POST /result-payment/create-batch?callbackUrl=<frontend-url>
+     * Body:     { examType: 'UBEAT' | 'BECE', examYear: number, studentIds: string[] }
+     * Response: { authorizationUrl, reference, studentCount, totalAmount }
+     *
+     * The `callbackUrl` query param is the URL Paystack will redirect the
+     * agent to after payment. We pass `window.location.origin + bulkRoute`
+     * so the agent lands back on the bulk-downloads page, which then fires
+     * `verifyBatchPayment(reference)` to confirm and refresh the cohort.
+     */
+    CREATE_BATCH_PAYMENT: '/result-payment/create-batch',
+    /**
+     * Verify a batch payment by its Paystack reference. The backend reads
+     * the saved `studentIds` from the transaction metadata and marks each
+     * student as paid when verification succeeds.
+     *
+     * URL:      GET /result-payment/verify/:reference
+     * Response: { statusCode, paymentStatus: 'successful' | 'failed' | 'pending', reference?, ... }
+     */
+    VERIFY_BATCH_PAYMENT: (reference: string) => `/result-payment/verify/${encodeURIComponent(reference)}`,
+    /**
+     * Voucher Receipt Lookup — fetch the full voucher record (school, exam,
+     * year, paid amount, and the list of student ids it covers) by its
+     * reference. The verify-batch response includes a `voucherReference`;
+     * the agent pastes it here to see which students they're entitled to
+     * download and to trigger the bulk download.
+     *
+     * URL:      GET /voucher/:voucherReference
+     * Response: VoucherResponse (see studentApi.ts)
+     */
+    GET_VOUCHER: (voucherReference: string) => `/voucher/${encodeURIComponent(voucherReference)}`,
+    /**
+     * Voucher Download — fetch student exam numbers and grades for the paid
+     * students on this voucher, triggering certificate generation + zipping
+     * on the backend.
+     *
+     * URL:      GET /voucher/:voucherReference/download
+     * Response: { schoolName, students: { studentName, examYear, examNo, grade }[] }
+     */
+    GET_VOUCHER_DOWNLOAD: (voucherReference: string) =>
+        `/voucher/${encodeURIComponent(voucherReference)}/download`,
     ONBOARD_STUDENT: '/onboarding',
     UPDATE_APPLICATION_STATUS: '/applications',
     CHANGE_PASSWORD: "/auth/change-password",

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkActionBar.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkActionBar.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import React from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { IoCardOutline, IoClose, IoSparkles } from 'react-icons/io5'
+import { formatNaira, type BulkExamConfig } from './examConfig'
+import type { BulkSelectionSummary } from './types'
+
+interface BulkActionBarProps {
+    config: BulkExamConfig
+    summary: BulkSelectionSummary
+    onPay: () => void
+    onClearSelection: () => void
+    /** True while a bulk payment or download mutation is in flight. */
+    isProcessing?: boolean
+    /** Optional label shown while processing. */
+    processingLabel?: string
+}
+
+/**
+ * Sticky bottom action bar that appears whenever the agent has at least
+ * one selection. Lives in a fixed container so it never overlaps content
+ * when the table is short.
+ */
+export default function BulkActionBar({
+    config,
+    summary,
+    onPay,
+    onClearSelection,
+    isProcessing = false,
+    processingLabel = 'Processing…',
+}: BulkActionBarProps) {
+    const { selectedCount, payableCount, downloadableCount, totalAmount } = summary
+    const visible = selectedCount > 0
+
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    initial={{ y: 80, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    exit={{ y: 80, opacity: 0 }}
+                    transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+                    role="region"
+                    aria-label="Bulk actions"
+                    className="fixed bottom-3 left-1/2 -translate-x-1/2 z-40 w-[calc(100vw-1.5rem)] max-w-5xl"
+                >
+                    <div className="bg-white border border-gray-200 rounded-2xl shadow-[0_12px_40px_rgba(0,0,0,0.12)] px-3 sm:px-5 py-3">
+                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+
+                            {/* Selection summary */}
+                            <div className="flex items-center gap-3 min-w-0">
+                                <button
+                                    type="button"
+                                    onClick={onClearSelection}
+                                    disabled={isProcessing}
+                                    title="Clear selection"
+                                    className="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    <IoClose className="w-4 h-4" />
+                                </button>
+
+                                <div className="flex items-center gap-2 min-w-0">
+                                    <div className="hidden sm:flex w-9 h-9 rounded-xl bg-green-50 text-green-600 items-center justify-center flex-shrink-0">
+                                        <IoSparkles className="w-4 h-4" />
+                                    </div>
+                                    <div className="min-w-0">
+                                        <p className="text-sm font-semibold text-gray-900 truncate">
+                                            {selectedCount} student{selectedCount === 1 ? '' : 's'} selected
+                                        </p>
+                                        <p className="text-[11px] text-gray-500 truncate">
+                                            {payableCount} unpaid · {downloadableCount} ready to download
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Total amount */}
+                            <div className="hidden md:flex items-center gap-2 flex-shrink-0 px-3 py-1.5 rounded-lg bg-gray-50 border border-gray-200">
+                                <span className="text-[11px] uppercase tracking-wide text-gray-500">Total due</span>
+                                <span className="text-sm font-bold text-gray-900 tabular-nums">
+                                    {formatNaira(totalAmount)}
+                                </span>
+                            </div>
+
+                            {/* Actions */}
+                            <div className="flex items-center gap-2 flex-shrink-0">
+                                <button
+                                    type="button"
+                                    onClick={onPay}
+                                    disabled={isProcessing || payableCount < 20}
+                                    className={[
+                                        'flex-1 md:flex-none inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold transition-all',
+                                        'text-white bg-green-600 hover:bg-green-700 cursor-pointer',
+                                        'disabled:opacity-50 disabled:cursor-not-allowed',
+                                        !isProcessing && payableCount >= 20
+                                            ? 'shadow-[0_4px_rgba(0,0,0,0.12)] active:shadow-[0_0px_rgba(0,0,0,1)] active:translate-y-1'
+                                            : '',
+                                    ].join(' ')}
+                                >
+                                    {isProcessing ? (
+                                        <>
+                                            <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                            <span className="hidden sm:inline">{processingLabel}</span>
+                                        </>
+                                    ) : payableCount > 0 && payableCount < 20 ? (
+                                        <>
+                                            <IoCardOutline className="w-4 h-4" />
+                                            <span>Select {20 - payableCount} more</span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <IoCardOutline className="w-4 h-4" />
+                                            <span className="hidden sm:inline">
+                                                Pay for {payableCount || ''} · {formatNaira(totalAmount)}
+                                            </span>
+                                            <span className="sm:hidden">Pay {formatNaira(totalAmount)}</span>
+                                        </>
+                                    )}
+                                </button>
+
+
+                            </div>
+                        </div>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkDownloadModal.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkDownloadModal.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import React from 'react'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { IoArchiveOutline, IoCheckmarkCircle, IoCloseCircle } from 'react-icons/io5'
+import type { BulkExamConfig } from './examConfig'
+
+export type BulkDownloadStage =
+    | 'idle'
+    | 'preparing'   // server is assembling the ZIP
+    | 'downloading' // browser is streaming the file
+    | 'done'
+    | 'error'
+
+interface BulkDownloadModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    config: BulkExamConfig
+    stage: BulkDownloadStage
+    /** 0-100, only meaningful when stage === 'preparing' | 'downloading'. */
+    progress?: number
+    /** Number of certificates expected in the ZIP. */
+    certificateCount: number
+    /** Optional error message — shown when stage === 'error'. */
+    errorMessage?: string
+    /** Retry handler for the error state. */
+    onRetry?: () => void
+}
+
+/**
+ * Progress modal for the bulk ZIP download.
+ *
+ * The progress bar uses a striped animation while preparing (no real %),
+ * then snaps to actual progress once the browser starts streaming.
+ */
+export default function BulkDownloadModal({
+    open,
+    onOpenChange,
+    config,
+    stage,
+    progress = 0,
+    certificateCount,
+    errorMessage,
+    onRetry,
+}: BulkDownloadModalProps) {
+    const isBusy = stage === 'preparing' || stage === 'downloading'
+    const showProgress = stage === 'downloading'
+
+    return (
+        <Dialog open={open} onOpenChange={isBusy ? undefined : onOpenChange}>
+            <DialogContent className="sm:max-w-md rounded-2xl p-0 overflow-hidden gap-0">
+                <div
+                    className={[
+                        'h-1.5 w-full',
+                        stage === 'error'
+                            ? 'bg-gradient-to-r from-red-500 to-red-600'
+                            : 'bg-gradient-to-r from-blue-500 to-blue-600',
+                    ].join(' ')}
+                />
+
+                <div className="p-6">
+                    <DialogHeader className="mb-4">
+                        <div
+                            className={[
+                                'flex items-center justify-center w-12 h-12 rounded-full mb-4 mx-auto border',
+                                stage === 'error'
+                                    ? 'bg-red-50 border-red-100'
+                                    : stage === 'done'
+                                        ? 'bg-green-50 border-green-100'
+                                        : 'bg-blue-50 border-blue-100',
+                            ].join(' ')}
+                        >
+                            {stage === 'error' ? (
+                                <IoCloseCircle className="w-6 h-6 text-red-600" />
+                            ) : stage === 'done' ? (
+                                <IoCheckmarkCircle className="w-6 h-6 text-green-600" />
+                            ) : (
+                                <IoArchiveOutline className="w-6 h-6 text-blue-600" />
+                            )}
+                        </div>
+
+                        <DialogTitle className="text-center text-lg font-semibold text-gray-900">
+                            {stage === 'error'
+                                ? 'Download failed'
+                                : stage === 'done'
+                                    ? 'Download complete'
+                                    : stage === 'preparing'
+                                        ? 'Preparing your ZIP…'
+                                        : `Downloading ${certificateCount} ${config.certificateLabel}s`}
+                        </DialogTitle>
+
+                        <DialogDescription className="text-sm text-gray-500 text-center mt-1 leading-relaxed">
+                            {stage === 'error'
+                                ? errorMessage ?? 'Something went wrong while building your ZIP file.'
+                                : stage === 'done'
+                                    ? `Your ZIP file has been saved. Look for ${config.zipFilenamePrefix}_<date>.zip in your downloads folder.`
+                                    : stage === 'preparing'
+                                        ? `We\u2019re packaging ${certificateCount} certificate${certificateCount === 1 ? '' : 's'}. This takes a few seconds.`
+                                        : 'Don\u2019t close this tab — the file is streaming to your device.'}
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {/* Progress bar */}
+                    {(stage === 'preparing' || stage === 'downloading') && (
+                        <div className="mb-4">
+                            <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
+                                {showProgress ? (
+                                    <div
+                                        className="h-full bg-blue-500 transition-[width] duration-300"
+                                        style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+                                    />
+                                ) : (
+                                    <div className="h-full w-1/3 bg-blue-500 animate-[pulse_1.4s_ease-in-out_infinite] rounded-full" />
+                                )}
+                            </div>
+                            {showProgress && (
+                                <p className="text-[11px] text-gray-500 mt-1.5 text-right tabular-nums">
+                                    {Math.round(progress)}%
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    <DialogFooter className="sm:justify-end gap-2">
+                        {stage === 'error' && onRetry && (
+                            <button
+                                type="button"
+                                onClick={onRetry}
+                                className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors cursor-pointer"
+                            >
+                                Try again
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => onOpenChange(false)}
+                            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {stage === 'done' ? 'Close' : isBusy ? 'Please wait…' : 'Cancel'}
+                        </button>
+                    </DialogFooter>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkDownloadsLanding.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkDownloadsLanding.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+    IoArrowBack,
+    IoArchiveOutline,
+    IoArrowForward,
+    IoCheckmarkCircle,
+    IoLayersOutline,
+    IoReceiptOutline,
+} from 'react-icons/io5'
+import { motion } from 'framer-motion'
+
+import { BULK_EXAM_CONFIGS, formatNaira, type BulkExamConfig } from './examConfig'
+
+interface ExamCardData {
+    config: BulkExamConfig
+    icon: React.ReactNode
+    accent: string
+    iconBg: string
+}
+
+const EXAM_CARDS: ExamCardData[] = [
+    {
+        config: BULK_EXAM_CONFIGS.bece,
+        icon: <IoLayersOutline className="w-6 h-6" />,
+        accent: 'from-emerald-50 to-green-50',
+        iconBg: 'bg-emerald-100 text-emerald-700',
+    },
+    {
+        config: BULK_EXAM_CONFIGS.ubeat,
+        icon: <IoArchiveOutline className="w-6 h-6" />,
+        accent: 'from-sky-50 to-blue-50',
+        iconBg: 'bg-sky-100 text-sky-700',
+    },
+]
+
+const BULK_FEATURES = [
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'Pay once for the whole cohort',
+    },
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'One ZIP file, all certificates',
+    },
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'Receipt emailed automatically',
+    },
+]
+
+const cardVariants = {
+    hidden: { opacity: 0, y: 14 },
+    visible: { opacity: 1, y: 0, transition: { type: 'spring' as const, stiffness: 260, damping: 26 } },
+}
+
+/**
+ * Exam-picker landing for the bulk-downloads agent flow.
+ *
+ * NOTE: Currently dead code — not imported by any `page.tsx`. The two
+ * `/result-checking/{bece,ubeat}/bulk-downloads/page.tsx` files render
+ * `BulkPageContent` directly, bypassing this picker. The intended route
+ * was `/result-checking/bulk-downloads` (a shared exam-picker screen) but
+ * that page was never created; the bulk-downloads flow is reached via
+ * the per-exam links from the main `/result-checking/{bece,ubeat}`
+ * landing pages instead. Wire this up by creating
+ * `src/app/result-checking/bulk-downloads/page.tsx` that renders
+ * `<BulkDownloadsLanding />` if the picker is ever wanted.
+ */
+export default function BulkDownloadsLanding() {
+    const router = useRouter()
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-green-50/40 via-white to-blue-50/30 flex flex-col">
+            {/* Top bar */}
+            <header className="bg-white border-b border-gray-100 sticky top-0 z-20">
+                <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between gap-3">
+                    <Link
+                        href="/result-checking"
+                        className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                    >
+                        <IoArrowBack className="w-4 h-4" />
+                        <span className="hidden sm:inline">Back to Student Portal</span>
+                        <span className="sm:hidden">Back</span>
+                    </Link>
+                    <div className="flex items-center gap-2">
+                        <Image
+                            src="/images/ministry-logo.png"
+                            alt="MOPSE"
+                            width={32}
+                            height={32}
+                            className="h-8 w-auto object-contain"
+                        />
+                        <div className="border-l border-gray-200 pl-2">
+                            <span className="text-sm font-semibold text-gray-900 block leading-tight">
+                                Bulk Downloads
+                            </span>
+                            <span className="text-[10px] text-gray-500 block leading-tight">
+                                Agent Portal
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            <main className="flex-1 max-w-6xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+                {/* Hero */}
+                <section className="mb-10">
+                    <div className="inline-flex items-center gap-2 bg-emerald-50 border border-emerald-100 text-emerald-700 text-xs font-semibold rounded-full px-3 py-1 mb-4">
+                        <IoReceiptOutline className="w-3.5 h-3.5" />
+                        <span>Agent-only · Whole-cohort processing</span>
+                    </div>
+                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-900 mb-3 leading-tight">
+                        Bulk Result Downloads
+                    </h1>
+                    <p className="text-base sm:text-lg text-gray-600 max-w-2xl leading-relaxed">
+                        Search a full school cohort, pay for every unpaid result in a single transaction,
+                        and download every certificate as one ZIP file. Pick the exam type to begin.
+                    </p>
+                </section>
+
+                {/* Exam picker */}
+                <section className="mb-10">
+                    <h2 className="text-lg font-bold text-gray-900 mb-4">Choose an examination</h2>
+                    <motion.div
+                        className="grid grid-cols-1 md:grid-cols-2 gap-5"
+                        initial="hidden"
+                        animate="visible"
+                        transition={{ staggerChildren: 0.08 }}
+                    >
+                        {EXAM_CARDS.map(({ config, icon, accent, iconBg }) => (
+                            <motion.button
+                                key={config.examType}
+                                variants={cardVariants}
+                                whileHover={{ y: -4 }}
+                                whileTap={{ scale: 0.99 }}
+                                onClick={() => router.push(config.bulkRoute)}
+                                className={[
+                                    'group text-left p-6 rounded-2xl bg-gradient-to-br',
+                                    accent,
+                                    'border border-white/80 shadow-sm hover:shadow-lg',
+                                    'transition-all duration-200 cursor-pointer',
+                                ].join(' ')}
+                            >
+                                <div className="flex items-start gap-4 mb-4">
+                                    <div
+                                        className={[
+                                            'flex items-center justify-center w-12 h-12 rounded-2xl flex-shrink-0',
+                                            iconBg,
+                                        ].join(' ')}
+                                    >
+                                        {icon}
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <h3 className="text-xl font-bold text-gray-900 mb-0.5">
+                                            {config.shortName}
+                                        </h3>
+                                        <p className="text-xs text-gray-600 font-medium">
+                                            {config.fullName}
+                                        </p>
+                                    </div>
+                                    <IoArrowForward className="w-5 h-5 text-gray-400 group-hover:text-gray-700 group-hover:translate-x-1 transition-all" />
+                                </div>
+
+                                <p className="text-sm text-gray-700 leading-relaxed mb-4">
+                                    Bulk-download {config.certificateLabel}s for an entire school cohort.
+                                    {' '}{formatNaira(config.pricePerStudent)} per certificate.
+                                </p>
+
+                                <ul className="space-y-1.5 mb-5">
+                                    {BULK_FEATURES.map((feature) => (
+                                        <li
+                                            key={feature.label}
+                                            className="flex items-center gap-2 text-xs text-gray-700"
+                                        >
+                                            {feature.icon}
+                                            <span>{feature.label}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+
+                                <div className="inline-flex items-center justify-center w-full py-2.5 rounded-lg text-sm font-semibold bg-white text-gray-900 border border-gray-200 group-hover:bg-gray-50 transition-colors">
+                                    Start {config.shortName} bulk download
+                                </div>
+                            </motion.button>
+                        ))}
+                    </motion.div>
+                </section>
+
+                {/* Helper banner */}
+                <section className="mb-10">
+                    <div className="bg-amber-50 border border-amber-100 rounded-2xl p-5 flex items-start gap-3">
+                        <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-white border border-amber-100 flex items-center justify-center">
+                            <span className="text-lg">💡</span>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <h3 className="text-sm font-semibold text-amber-900 mb-1">
+                                How bulk downloads work
+                            </h3>
+                            <ol className="text-sm text-amber-900/80 space-y-1 list-decimal list-inside">
+                                <li>Pick the exam, then the year, LGA and school.</li>
+                                <li>Select the students whose certificates you need.</li>
+                                <li>
+                                    Pay {formatNaira(BULK_EXAM_CONFIGS.bece.pricePerStudent)} per unpaid student in a single transaction.
+                                </li>
+                                <li>Download every paid certificate as a ZIP file.</li>
+                            </ol>
+                        </div>
+                    </div>
+                </section>
+
+                {/* Single-student fallback */}
+                <section className="text-center">
+                    <p className="text-xs text-gray-500">
+                        Only need one student’s result?{' '}
+                        <Link
+                            href="/result-checking"
+                            className="text-green-600 hover:text-green-700 font-medium"
+                        >
+                            Go to the standard student portal
+                        </Link>
+                    </p>
+                </section>
+            </main>
+
+            <footer className="border-t border-gray-100 py-6 bg-gray-50">
+                <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                    <p className="text-xs text-gray-500">
+                        © {new Date().getFullYear()} Imo State Ministry of Primary and Secondary Education
+                    </p>
+                </div>
+            </footer>
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkPageContent.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkPageContent.tsx
@@ -1,0 +1,918 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useDispatch } from 'react-redux'
+import { IoCheckmarkCircle, IoChevronDown, IoCopyOutline, IoSearch, IoSwapHorizontal } from 'react-icons/io5'
+import toast from 'react-hot-toast'
+
+import PortalHeader from '@/app/result-checking/components/Portalheader'
+import BulkSearchForm from './BulkSearchForm'
+import SearchFilterSummary from './SearchFilterSummary'
+import StudentResultsTable from './StudentResultsTable'
+import BulkActionBar from './BulkActionBar'
+import BulkPaymentModal from './BulkPaymentModal'
+import BulkDownloadModal, { type BulkDownloadStage } from './BulkDownloadModal'
+import VoucherLookup from './VoucherLookup'
+import {
+    useCreateBatchPaymentMutation,
+    useGetBulkStudentsBySchoolQuery,
+    useLazyGetVoucherDownloadQuery,
+    useVerifyBatchPaymentQuery,
+    getVerifiedStudentCount,
+    studentApi,
+    type VoucherResponse,
+} from '@/app/result-checking/store/api/studentApi'
+import { ExamTypeEnum } from '@/app/portal/store/api/authApi'
+import { mapBulkStudentListItem } from './bulkApiAdapter'
+import { type BulkExamConfig } from './examConfig'
+import {
+    saveVoucherToStorage,
+    loadVoucherFromStorage,
+    hasVoucherInStorage,
+    clearVoucherFromStorage,
+} from './voucherStorage'
+import type {
+    BulkSearchFilters,
+    BulkSelectionSummary,
+    BulkStatusFilter,
+    BulkStudent,
+} from './types'
+
+interface BulkPageContentProps {
+    config: BulkExamConfig
+}
+
+const DEFAULT_FILTERS: BulkSearchFilters = {
+    examYear: '',
+    lga: '',
+    school: { id: '', name: '' },
+}
+
+const ITEMS_PER_PAGE_DEFAULT = 12
+
+/** Normalize a string for case- and whitespace-insensitive matching. */
+function normalizeForSearch(value: string): string {
+    return value.trim().toLowerCase()
+}
+
+/**
+ * Top-level client component for `/bulk-downloads/{bece,ubeat}`.
+ *
+ * Owns all UI state:
+ *   - search form values & "form vs. results" mode
+ *   - in-table search query + status filter (All / Unpaid / Paid)
+ *   - client-side paginated cohort, items-per-page
+ *   - per-row selection set (with cross-page select-all matching)
+ *   - payment + download modal states
+ *
+ * Data flow:
+ *   1. User picks year + LGA + school in `BulkSearchForm`
+ *   2. We POST to `/{examType}/students/by-school` via RTK Query
+ *   3. The minimal `BulkStudentListItem` response is mapped to `BulkStudent`
+ *      (see `bulkApiAdapter.ts`)
+ *   4. The cohort is sliced by status filter → search → page
+ */
+export default function BulkPageContent({ config }: BulkPageContentProps) {
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const dispatch = useDispatch()
+
+    // ── Search state ─────────────────────────────────────────────────────
+    const [filters, setFilters] = useState<BulkSearchFilters>(DEFAULT_FILTERS)
+    const [appliedFilters, setAppliedFilters] = useState<BulkSearchFilters | null>(null)
+
+    // ── Toolbar (in-table) state ─────────────────────────────────────────
+    const [searchQuery, setSearchQuery] = useState('')
+    const [statusFilter, setStatusFilter] = useState<BulkStatusFilter>('all')
+
+    // ── Pagination ───────────────────────────────────────────────────────
+    const [currentPage, setCurrentPage] = useState(1)
+    const [itemsPerPage, setItemsPerPage] = useState(ITEMS_PER_PAGE_DEFAULT)
+
+    // ── Selection ────────────────────────────────────────────────────────
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+    // ── Modal / download state ───────────────────────────────────────────
+    const [isPaying, setIsPaying] = useState(false)
+    const [paymentOpen, setPaymentOpen] = useState(false)
+    const [downloadStage, setDownloadStage] = useState<BulkDownloadStage>('idle')
+    const [downloadProgress, setDownloadProgress] = useState(0)
+    const [downloadOpen, setDownloadOpen] = useState(false)
+    /**
+     * Number of certificates the modal is currently simulating a download
+     * for. Driven by whichever entry point opened the modal (selection-
+     * based or voucher-based). Read by the modal's `certificateCount` prop
+     * and its `onRetry` button.
+     */
+    const [downloadCertificateCount, setDownloadCertificateCount] = useState(0)
+    const [downloadVoucherRef, setDownloadVoucherRef] = useState('')
+    /**
+     * Voucher reference from the URL — kept for direct `?voucher=…` links
+     * (e.g. bookmarks). After a successful verify, we store the full
+     * voucher in localStorage instead and skip the URL param.
+     */
+    const urlVoucher = searchParams.get('voucher') ?? ''
+
+    // ── Saved voucher from localStorage ─────────────────────────────────
+    const [savedVoucher, setSavedVoucher] = useState<VoucherResponse | null>(null)
+    const [verifiedAt, setVerifiedAt] = useState<string | null>(null)
+
+    const [voucherRefModal, setVoucherRefModal] = useState<string | null>(null)
+
+    // On mount, try to load a previously-saved voucher from localStorage.
+    // This runs once per mount — only when there's no `?reference=` callback
+    // and no `?voucher=` in the URL (those take priority).
+    useEffect(() => {
+        const ref = searchParams.get('reference') ?? searchParams.get('trxref')
+        const vch = searchParams.get('voucher')
+        if (ref || vch) return // active callback or direct link — don't load saved
+
+        if (!hasVoucherInStorage(config.examType)) return
+
+        loadVoucherFromStorage(config.examType).then(v => {
+            if (v) setSavedVoucher(v)
+        })
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+    /**
+     * Whether the (secondary) cohort search section is expanded. Default
+     * collapsed — the voucher view at the top is the primary entry point
+     * and the LGA × School search is only needed when the agent hasn't
+     * paid yet. Auto-expands the first time the user submits a search so
+     * they can see their cohort without an extra click.
+     */
+    const [cohortExpanded, setCohortExpanded] = useState(false)
+    const [voucherActive, setVoucherActive] = useState(false)
+
+    const handleClearSavedVoucher = useCallback(() => {
+        clearVoucherFromStorage(config.examType)
+        setSavedVoucher(null)
+        setVerifiedAt(null)
+        setVoucherActive(false)
+    }, [config.examType])
+
+    const handleDismissVoucherModal = useCallback(async () => {
+        if (voucherRefModal) {
+            try {
+                await navigator.clipboard.writeText(voucherRefModal)
+                toast.success('Voucher reference copied!')
+            } catch {
+                // clipboard not available — user can still copy manually
+            }
+        }
+        setVoucherRefModal(null)
+        router.replace(config.bulkRoute)
+    }, [voucherRefModal, router, config.bulkRoute])
+
+    const handleVoucherLoaded = useCallback(
+        async (voucher: VoucherResponse) => {
+            await saveVoucherToStorage(config.examType, voucher)
+            setSavedVoucher(voucher)
+        },
+        [config.examType],
+    )
+
+    useEffect(() => {
+        if (appliedFilters) setCohortExpanded(true)
+    }, [appliedFilters])
+
+    // ── Live cohort query ────────────────────────────────────────────────
+    // Server-side pagination + status filter. The response is a single page
+    // (currentPage) of the (status-filtered) cohort. Free-text search is
+    // still applied client-side on the current page (see `matchingCohort`).
+    const yearNum = appliedFilters ? Number(appliedFilters.examYear) : NaN
+    const queryArgs = appliedFilters && Number.isFinite(yearNum) && appliedFilters.school.id
+        ? {
+            examType: config.examType === 'bece'
+                ? ExamTypeEnum.BECE
+                : ExamTypeEnum.UBEAT,
+            year: yearNum,
+            lga: appliedFilters.lga,
+            schoolId: appliedFilters.school.id,
+            page: currentPage,
+            limit: itemsPerPage,
+            paymentStatus: statusFilter === 'all' ? undefined : statusFilter,
+        }
+        : undefined
+
+    const {
+        data: apiResponse,
+        isLoading: isLoadingCohort,
+        isFetching: isFetchingCohort,
+        error: cohortError,
+    } = useGetBulkStudentsBySchoolQuery(queryArgs!, {
+        skip: !queryArgs,
+    })
+
+    // Map the current page's items to the wider BulkStudent shape.
+    const currentPageStudents: BulkStudent[] = useMemo(() => {
+        if (!apiResponse || !appliedFilters) return []
+        return apiResponse.data.map(item =>
+            mapBulkStudentListItem(item, {
+                schoolId: appliedFilters.school.id,
+                schoolName: appliedFilters.school.name,
+                lga: appliedFilters.lga,
+                examYear: appliedFilters.examYear,
+            }),
+        )
+    }, [apiResponse, appliedFilters])
+
+    // Client-side search filter — narrows the *current page* to the rows
+    // whose name matches. The toolbar's "matchingCount" reflects this
+    // per-page number, so "Select all N" selects every matching row on
+    // the visible page. The user flips pages to accumulate selections.
+    const matchingCohort: BulkStudent[] = useMemo(() => {
+        const needle = normalizeForSearch(searchQuery)
+        if (!needle) return currentPageStudents
+        return currentPageStudents.filter(s =>
+            normalizeForSearch(s.studentName).includes(needle),
+        )
+    }, [currentPageStudents, searchQuery])
+
+    const students: BulkStudent[] = matchingCohort
+
+    // Server-reported totals for the currently status-filtered cohort.
+    const serverTotalItems = apiResponse?.pagination?.total ?? 0
+    const serverTotalPages = apiResponse?.pagination?.totalPages ?? 1
+
+    // Surface API errors as toasts.
+    useEffect(() => {
+        if (cohortError) {
+            const message =
+                'status' in cohortError && cohortError.status === 404
+                    ? 'No students found for that school, LGA, and year.'
+                    : 'Could not load the cohort. Please try again.'
+            toast.error(message)
+        }
+    }, [cohortError])
+
+    // Clamp the current page *only* when it's out of bounds (e.g. the user
+    // changed items-per-page or applied a filter that shrunk the cohort).
+    // We deliberately do NOT reset the page just because the server's last
+    // response was for a different page — that would race with the user's
+    // own navigation clicks and effectively freeze the pagination on page 1.
+    useEffect(() => {
+        if (
+            apiResponse &&
+            serverTotalPages > 0 &&
+            currentPage > serverTotalPages
+        ) {
+            setCurrentPage(serverTotalPages)
+        }
+    }, [apiResponse, serverTotalPages, currentPage])
+
+    // ── Derived selection summary ────────────────────────────────────────
+    const summary: BulkSelectionSummary = useMemo(() => {
+        const selectedOnPage = students.filter(s => selectedIds.has(s._id))
+        const selectedOffPage = selectedIds.size - selectedOnPage.length
+
+        const payableCount =
+            selectedOnPage.filter(s => s.paymentStatus !== 'paid').length + selectedOffPage
+        const downloadableCount = selectedOnPage.filter(
+            s => s.paymentStatus === 'paid' && s.certificateReady,
+        ).length
+
+        return {
+            selectedCount: selectedIds.size,
+            payableCount,
+            downloadableCount,
+            totalAmount: payableCount * config.pricePerStudent,
+        }
+    }, [students, selectedIds, config.pricePerStudent])
+
+    // ── Shift-click selection refs ───────────────────────────────────────
+    // Ref to the current visible student list so the toggle callback can
+    // read indices without re-creating itself on every render.
+    const studentsRef = useRef(students)
+    studentsRef.current = students
+    // Tracks the last individually-clicked row index for shift-click ranges.
+    const lastClickedRef = useRef<number | null>(null)
+    const resetAnchor = useCallback(() => { lastClickedRef.current = null }, [])
+
+    // ── Filter / pagination handlers ─────────────────────────────────────
+    const handleSearchSubmit = useCallback(() => {
+        setAppliedFilters(filters)
+        setCurrentPage(1)
+        setSelectedIds(new Set())
+        setSearchQuery('')
+        setStatusFilter('all')
+        resetAnchor()
+    }, [filters, resetAnchor])
+
+    const handleChangeFilters = useCallback(() => {
+        setAppliedFilters(null)
+        setSelectedIds(new Set())
+        setCurrentPage(1)
+        setSearchQuery('')
+        setStatusFilter('all')
+        setVoucherActive(false)
+        resetAnchor()
+        if (typeof window !== 'undefined') {
+            window.scrollTo({ top: 0, behavior: 'smooth' })
+        }
+    }, [resetAnchor])
+
+    const handlePageChange = useCallback((page: number) => {
+        setCurrentPage(page)
+        resetAnchor()
+        if (typeof window !== 'undefined') {
+            window.scrollTo({ top: 120, behavior: 'smooth' })
+        }
+    }, [resetAnchor])
+
+    const handleItemsPerPageChange = useCallback((n: number) => {
+        setItemsPerPage(n)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    const handleSearchInputChange = useCallback((value: string) => {
+        setSearchQuery(value)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    const handleStatusFilterChange = useCallback((value: BulkStatusFilter) => {
+        setStatusFilter(value)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    /**
+     * Quick "show all students" — used by the EmptyState's primary CTA
+     * so the user can recover from a dead-end filter without leaving
+     * the results screen or losing their other filter context.
+     */
+    const handleShowAllStatuses = useCallback(() => {
+        setStatusFilter('all')
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    // ── Selection handlers ───────────────────────────────────────────────
+    const toggleOne = useCallback((id: string, event?: React.MouseEvent) => {
+        const list = studentsRef.current
+        const currentIdx = list.findIndex(s => s._id === id)
+        if (currentIdx === -1) return
+
+        if (event?.shiftKey && lastClickedRef.current !== null) {
+            const from = Math.min(lastClickedRef.current, currentIdx)
+            const to = Math.max(lastClickedRef.current, currentIdx)
+            setSelectedIds(prev => {
+                const next = new Set(prev)
+                for (let i = from; i <= to; i++) {
+                    const student = list[i]
+                    if (student.paymentStatus !== 'paid') next.add(student._id)
+                }
+                return next
+            })
+        } else {
+            lastClickedRef.current = currentIdx
+            setSelectedIds(prev => {
+                const next = new Set(prev)
+                if (next.has(id)) next.delete(id)
+                else next.add(id)
+                return next
+            })
+        }
+    }, [])
+
+    const clearSelection = useCallback(() => {
+        setSelectedIds(new Set())
+    }, [])
+
+    // ── Voucher download ────────────────────────────────────────────────
+    const [triggerDownload, { isLoading: isDownloading }] = useLazyGetVoucherDownloadQuery()
+
+    // ── Bulk payment ────────────────────────────────────────────────────
+    const [createBatchPayment] = useCreateBatchPaymentMutation()
+
+    const handleStartPayment = useCallback(() => {
+        if (summary.payableCount === 0) {
+            toast('Nothing to pay — your selection is already paid.', { icon: 'ℹ️' })
+            return
+        }
+        if (summary.payableCount < 20) {
+            toast.error(`Select at least 20 unpaid students to proceed (you have ${summary.payableCount}).`)
+            return
+        }
+        if (!appliedFilters) {
+            toast.error('Pick a year, LGA, and school before paying.')
+            return
+        }
+        setPaymentOpen(true)
+    }, [summary.payableCount, appliedFilters])
+
+    const handleConfirmPayment = useCallback(async (_args: { email: string }): Promise<string | undefined> => {
+        // The `email` arg is received for signature parity with the
+        // Paywall's EmailDialog, but the BulkPaymentModal is responsible
+        // for PATCHing it onto the payment after this function returns
+        // (it calls `setBecePaymentEmail` / `setUbeatPaymentEmail` once
+        // the reference is in hand, racing the redirect). We don't use
+        // it here.
+        if (!appliedFilters) return undefined
+
+        // Send the agent's full `selectedIds` as the `studentIds` payload.
+        // The backend dedupes against already-paid students, so it's safe to
+        // include paid rows that are still in the cross-page selection set
+        // (e.g. an agent who ticked a row, refreshed, then re-ticked it).
+        const studentIds = Array.from(selectedIds)
+        if (studentIds.length === 0) {
+            toast.error('No students selected.')
+            return undefined
+        }
+
+        // ── Sticky loading: set true ONCE here. From this point on, the
+        // BulkActionBar shows "Starting payment…" and is disabled. Do NOT
+        // reset isPaying on the success path — the page is about to
+        // navigate and we don't want the action bar to re-enable mid-
+        // navigation. Only the catch block may reset it.
+        setIsPaying(true)
+        try {
+            const callbackUrl =
+                typeof window !== 'undefined'
+                    ? `${window.location.origin}${config.bulkRoute}`
+                    : config.bulkRoute
+
+            const yearNum = Number(appliedFilters.examYear)
+            const response = await createBatchPayment({
+                examType: config.examType === 'bece' ? ExamTypeEnum.BECE : ExamTypeEnum.UBEAT,
+                examYear: yearNum,
+                studentIds,
+                callbackUrl,
+            }).unwrap()
+
+            if (!response.authorizationUrl) {
+                toast.error('Payment gateway did not return a checkout URL. Please try again.')
+                setIsPaying(false)
+                return undefined
+            }
+
+            // Stash the original selection under the reference so the verify
+            // effect (run after Paystack redirects back) can clear the
+            // agent's selection set in the same shape it was in before pay.
+            if (typeof window !== 'undefined') {
+                window.sessionStorage.setItem(
+                    `bulk-payment-selection:${response.reference}`,
+                    JSON.stringify(studentIds),
+                )
+            }
+
+            // ── Sticky loading: redirect is triggered. From this point
+            // forward, do NOT touch isPaying under any code path. The page
+            // is navigating and the action bar should stay disabled.
+            toast.success('Redirecting to Paystack…')
+            window.location.href = response.authorizationUrl
+            return response.reference
+        } catch (err) {
+            console.error('Batch payment initiation failed', err)
+            const apiMessage: string | undefined =
+                err && typeof err === 'object' && 'data' in err
+                    ? (err as { data?: { message?: string } }).data?.message
+                    : undefined
+            toast.error(apiMessage || 'Could not start the payment. Please try again.')
+            // Failure path: reset isPaying so the agent can retry.
+            setIsPaying(false)
+            return undefined
+        }
+    }, [appliedFilters, selectedIds, createBatchPayment, config.bulkRoute, config.examType])
+
+    // ── Bulk ZIP download ───────────────────────────────────────────────
+    // Calls the real `/voucher/:ref/download` endpoint which triggers
+    // certificate generation + zipping on the backend. The modal shows
+    // a "preparing" → "downloading" → "done" progression.
+
+    /**
+     * Voucher-driven bulk download: hits the real download endpoint to
+     * trigger certificate generation and zipping.
+     */
+    const handleVoucherDownloadAll = useCallback(
+        (_paidIds: string[], voucher: VoucherResponse) => {
+            if (_paidIds.length === 0) {
+                toast('No paid students on this voucher.', { icon: 'ℹ️' })
+                return
+            }
+            setDownloadCertificateCount(_paidIds.length)
+            setDownloadVoucherRef(voucher.voucherReference)
+            setDownloadStage('preparing')
+            setDownloadProgress(0)
+            setDownloadOpen(true)
+
+            triggerDownload(voucher.voucherReference)
+                .unwrap()
+                .then(() => {
+                    setDownloadProgress(100)
+                    setDownloadStage('done')
+                })
+                .catch(() => {
+                    toast.error('Could not generate certificates. Please try again.')
+                    setDownloadStage('idle')
+                    setDownloadOpen(false)
+                })
+        },
+        [triggerDownload],
+    )
+
+    const handleRetryDownload = useCallback(() => {
+        if (!downloadVoucherRef) return
+        setDownloadStage('preparing')
+        setDownloadProgress(0)
+        triggerDownload(downloadVoucherRef)
+            .unwrap()
+            .then(() => {
+                setDownloadProgress(100)
+                setDownloadStage('done')
+            })
+            .catch(() => {
+                toast.error('Could not generate certificates. Please try again.')
+                setDownloadStage('idle')
+                setDownloadOpen(false)
+            })
+    }, [downloadVoucherRef, triggerDownload])
+
+    // ── Verify batch payment on Paystack callback ──────────────────────
+    // When Paystack redirects back to `config.bulkRoute?reference=BATCH-…`
+    // (or `?trxref=BATCH-…`), we call the verify endpoint. On a successful
+    // verify, we invalidate the `Students` tag so the cohort refetches
+    // and shows the newly-paid rows; on a failed/pending verify, we toast
+    // and let the agent retry.
+    const reference = searchParams.get('reference') ?? searchParams.get('trxref')
+    const {
+        data: verifyData,
+        isLoading: isVerifying,
+        isSuccess: isVerifySuccess,
+        isError: isVerifyError,
+    } = useVerifyBatchPaymentQuery(reference ?? '', { skip: !reference })
+
+    // Guard so we only react to *one* resolution of the verify query.
+    // Without this, the effect would re-fire on every render that
+    // re-creates `verifyData` (e.g. when the router.replace flushes state).
+    const handledRef = useRef<string | null>(null)
+    useEffect(() => {
+        if (!reference) {
+            handledRef.current = null
+            return
+        }
+        if (handledRef.current === reference) return
+
+        if (isVerifySuccess && verifyData) {
+            const ok =
+                verifyData.statusCode === 200 ||
+                verifyData.statusCode === undefined ||
+                verifyData.paymentStatus === 'successful'
+            if (ok) {
+                handledRef.current = reference
+                const studentCount = getVerifiedStudentCount(verifyData)
+                toast.success(
+                    `Bulk payment confirmed${
+                        studentCount ? ` for ${studentCount} student${studentCount === 1 ? '' : 's'}` : ''
+                    }.`,
+                )
+                dispatch(studentApi.util.invalidateTags([{ type: 'Students' }]))
+
+                if (verifyData.voucherReference) {
+                    // Fetch the full voucher response so we can save it to
+                    // localStorage and display it immediately.
+                    const promise = dispatch(
+                        studentApi.endpoints.getVoucher.initiate(verifyData.voucherReference) as any,
+                    ) as any
+                    promise
+                        .unwrap()
+                        .then(async (voucherResult: VoucherResponse) => {
+                            await saveVoucherToStorage(config.examType, voucherResult)
+                            setSavedVoucher(voucherResult)
+                            setVerifiedAt(new Date().toISOString())
+                            setVoucherRefModal(voucherResult.voucherReference)
+                        })
+                        .catch(() => {
+                            console.warn('Failed to fetch voucher after verify — falling back to URL param.')
+                            const ref = verifyData.voucherReference ?? ''
+                            router.replace(
+                                `${config.bulkRoute}?voucher=${encodeURIComponent(ref)}`,
+                            )
+                        })
+                } else {
+                    router.replace(config.bulkRoute)
+                }
+            } else if (verifyData.paymentStatus === 'pending') {
+                // Paystack's webhook hasn't settled yet. The agent may
+                // have closed the Paystack tab before the backend finished
+                // marking students paid. We mark this reference as handled
+                // (so the effect doesn't re-fire on every render) but
+                // leave the `?reference=...` in the URL — the agent can
+                // refresh the page to re-check, and the verify overlay
+                // will re-appear until the backend confirms.
+                handledRef.current = reference
+                toast(
+                    'Your payment is still being processed. Please refresh this page in a few seconds.',
+                    { icon: '⏳' },
+                )
+            } else {
+                handledRef.current = reference
+                toast.error('Bulk payment was not successful. No charges have been made.')
+                router.replace(config.bulkRoute)
+            }
+        }
+
+        if (isVerifyError) {
+            handledRef.current = reference
+            toast.error('Could not verify the payment. If you were charged, please contact support.')
+            router.replace(config.bulkRoute)
+        }
+    }, [
+        reference,
+        isVerifySuccess,
+        isVerifyError,
+        verifyData,
+        dispatch,
+        router,
+        config.bulkRoute,
+    ])
+
+    // Legacy callback: some backends redirect with `?payment=success/failed`
+    // (without a `reference`). Keep the toast behaviour for that flow but
+    // don't fire the verify call — there's no reference to verify against.
+    useEffect(() => {
+        const status = searchParams.get('payment')
+        if (status && !reference) {
+            if (status === 'success') {
+                toast.success('Bulk payment confirmed. Refreshing the cohort…')
+                dispatch(studentApi.util.invalidateTags([{ type: 'Students' }]))
+            } else if (status === 'failed') {
+                toast.error('Bulk payment failed. No charges have been made.')
+            }
+            router.replace(config.bulkRoute)
+        }
+    }, [searchParams, reference, dispatch, router, config.bulkRoute])
+
+    // ── Render ──────────────────────────────────────────────────────────
+    const showResults = !!appliedFilters
+    const isTableLoading = isLoadingCohort || isFetchingCohort
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex flex-col">
+            <PortalHeader
+                title={`Bulk ${config.shortName} Downloads`}
+                subtitle={config.subtitle}
+                actions={[
+                    {
+                        key: 'switch-exam',
+                        label: 'Switch Exam',
+                        icon: <IoSwapHorizontal className="w-4 h-4" />,
+                        onClick: () =>
+                            router.push(
+                                config.examType === 'bece'
+                                    ? '/result-checking/ubeat/bulk-downloads'
+                                    : '/result-checking/bece/bulk-downloads',
+                            ),
+                        variant: 'secondary',
+                        hideOnMobileTray: true,
+                    },
+                ]}
+            />
+
+            <main className="flex-1 max-w-6xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 pb-32">
+
+                {/* Step 1: Voucher lookup — the primary entry point. Agent
+                    can paste a voucher ref and go straight to download,
+                    bypassing the LGA × School search entirely. Auto-
+                    fetches when `?voucher=…` is in the URL (i.e. after a
+                    successful payment verify pushes it there). The
+                    component has its own hero header. Hidden while the
+                    cohort search is open (mutual exclusion). */}
+                {!cohortExpanded && (
+                    <section className="mb-6">
+                        <VoucherLookup
+                            config={config}
+                            initialValue={urlVoucher}
+                            autoFetch
+                            onDownloadAll={handleVoucherDownloadAll}
+                            onActiveChange={setVoucherActive}
+                            onVoucherLoaded={handleVoucherLoaded}
+                            savedVoucher={savedVoucher}
+                            verifiedAt={verifiedAt}
+                            onClearSaved={handleClearSavedVoucher}
+                        />
+                    </section>
+                )}
+
+                {/* Step 2: Cohort search — collapsible expander. The agent
+                    only needs this when they haven't paid yet. Default
+                    collapsed; auto-expands the first time a search is
+                    submitted. Hidden entirely when a voucher is active
+                    (mutual exclusion). */}
+                {!voucherActive && (
+                    <section className="mb-6">
+                    <button
+                        type="button"
+                        onClick={() => setCohortExpanded(v => !v)}
+                        aria-expanded={cohortExpanded}
+                        aria-controls="cohort-search-panel"
+                        className={[
+                            'group w-full flex items-center justify-between gap-3 px-5 sm:px-6 py-4 rounded-2xl border bg-white transition-colors cursor-pointer text-left',
+                            cohortExpanded
+                                ? 'border-gray-300'
+                                : 'border-gray-200 hover:border-gray-300',
+                        ].join(' ')}
+                    >
+                        <div className="flex items-center gap-3 min-w-0">
+                            <div className="w-9 h-9 rounded-lg bg-gray-100 text-gray-600 flex items-center justify-center flex-shrink-0">
+                                <IoSearch className="w-4 h-4" />
+                            </div>
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-gray-900">
+                                    Don&apos;t have a voucher yet?
+                                </p>
+                                <p className="text-xs text-gray-500 mt-0.5">
+                                    Pay for your school&apos;s certificates first
+                                </p>
+                            </div>
+                        </div>
+                        <IoChevronDown
+                            className={[
+                                'w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-200 group-hover:text-gray-600',
+                                cohortExpanded ? 'rotate-180' : '',
+                            ].join(' ')}
+                        />
+                    </button>
+
+                    {cohortExpanded && (
+                        <div id="cohort-search-panel" className="mt-4 space-y-4">
+                            {/* Search form — only when no search submitted yet */}
+                            {!showResults && (
+                                <BulkSearchForm
+                                    config={config}
+                                    value={filters}
+                                    onChange={setFilters}
+                                    onSubmit={handleSearchSubmit}
+                                    isLoading={isTableLoading}
+                                />
+                            )}
+
+                            {/* Results */}
+                            {showResults && appliedFilters && (
+                                <>
+                                    <SearchFilterSummary
+                                        filters={appliedFilters}
+                                        totalItems={serverTotalItems}
+                                        onEdit={handleChangeFilters}
+                                    />
+
+                                    <StudentResultsTable
+                                        config={config}
+                                        students={students}
+                                        selectedIds={selectedIds}
+                                        onToggleOne={toggleOne}
+                                        isLoading={isTableLoading}
+                                        currentPage={currentPage}
+                                        totalPages={serverTotalPages}
+                                        totalItems={serverTotalItems}
+                                        statusFilteredCount={serverTotalItems}
+                                        matchingCount={students.length}
+                                        itemsPerPage={itemsPerPage}
+                                        onPageChange={handlePageChange}
+                                        onItemsPerPageChange={handleItemsPerPageChange}
+                                        disabled={
+                                            isPaying ||
+                                            downloadStage === 'preparing' ||
+                                            downloadStage === 'downloading'
+                                        }
+                                        onChangeFilters={handleChangeFilters}
+                                        searchQuery={searchQuery}
+                                        onSearchChange={handleSearchInputChange}
+                                        statusFilter={statusFilter}
+                                        onStatusFilterChange={handleStatusFilterChange}
+                                        emptyStateContext={{
+                                            isSearching: searchQuery.trim() !== '',
+                                            searchQuery,
+                                            statusFilter,
+                                            onClearSearch: () => handleSearchInputChange(''),
+                                            onShowAllStatuses: handleShowAllStatuses,
+                                            onSwitchStatus: handleStatusFilterChange,
+                                        }}
+                                    />
+                                </>
+                            )}
+                        </div>
+                    )}
+                </section>
+                )}
+
+                {/* Footer link */}
+                <footer className="mt-8 text-center space-y-2">
+                    <p className="text-xs text-gray-500">
+                        Need a single student instead?{' '}
+                        <Link
+                            href={config.singleStudentRoute}
+                            className="text-gray-900 hover:text-gray-700 font-medium"
+                        >
+                            Go to the standard {config.shortName} portal
+                        </Link>
+                    </p>
+                    <p className="text-xs text-gray-400">
+                        Stuck or lost your voucher? Reach out on the support chat and we&apos;ll
+                        help.
+                    </p>
+                </footer>
+            </main>
+
+            {/* Sticky bulk action bar */}
+            <BulkActionBar
+                config={config}
+                summary={summary}
+                onPay={handleStartPayment}
+                onClearSelection={clearSelection}
+                isProcessing={isPaying || downloadStage === 'preparing'}
+                processingLabel={isPaying ? 'Starting payment…' : 'Preparing ZIP…'}
+            />
+
+            {/* Bulk payment modal */}
+            <BulkPaymentModal
+                open={paymentOpen}
+                onOpenChange={setPaymentOpen}
+                config={config}
+                summary={summary}
+                schoolName={appliedFilters?.school.name ?? ''}
+                onConfirm={handleConfirmPayment}
+            />
+
+            {/* Bulk download modal */}
+            <BulkDownloadModal
+                open={downloadOpen}
+                onOpenChange={(open) => {
+                    setDownloadOpen(open)
+                    if (!open) setDownloadStage('idle')
+                }}
+                config={config}
+                stage={downloadStage}
+                progress={downloadProgress}
+                certificateCount={downloadCertificateCount}
+                onRetry={handleRetryDownload}
+            />
+
+            {/* Verifying-payment overlay — shown when Paystack redirects
+                back with `?reference=…` and the verify call is in flight.
+                Hides automatically when the verify resolves (success or
+                error → `router.replace` scrubs the URL; pending → effect
+                toasts and the overlay remains visible until the agent
+                refreshes the page). */}
+            {reference && isVerifying && (
+                <div
+                    role="status"
+                    aria-live="polite"
+                    className="fixed inset-0 z-50 bg-white/85 backdrop-blur-sm flex items-center justify-center p-4"
+                >
+                    <div className="bg-white rounded-2xl shadow-2xl border border-gray-200 max-w-md w-full overflow-hidden">
+                        <div className="h-1.5 w-full bg-gray-900" />
+                        <div className="p-8 text-center">
+                            <div className="w-16 h-16 rounded-full bg-gray-50 border-2 border-gray-100 mx-auto mb-5 flex items-center justify-center">
+                                <span className="w-8 h-8 border-[3px] border-gray-200 border-t-gray-900 rounded-full animate-spin" />
+                            </div>
+                            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                                Verifying your payment
+                            </h2>
+                            <p className="text-sm text-gray-600 leading-relaxed">
+                                We&apos;re confirming your bulk payment with Paystack. This usually takes a few seconds — please don&apos;t close or refresh this tab.
+                            </p>
+                            <p className="text-[11px] text-gray-400 mt-4 font-mono break-all">
+                                {reference}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {voucherRefModal && (
+                <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+                    <div className="bg-white rounded-2xl shadow-2xl border border-gray-200 max-w-md w-full overflow-hidden">
+                        <div className="h-1.5 w-full bg-gray-900" />
+                        <div className="p-8 text-center">
+                            <div className="w-16 h-16 rounded-full bg-gray-50 border-2 border-gray-100 mx-auto mb-5 flex items-center justify-center">
+                                <IoCheckmarkCircle className="w-8 h-8 text-gray-900" />
+                            </div>
+                            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                                Payment confirmed!
+                            </h2>
+                            <p className="text-sm text-gray-600 leading-relaxed mb-6">
+                                Broski, this is your voucher reference. Click it to copy.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={handleDismissVoucherModal}
+                                className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-800 transition-colors cursor-pointer"
+                            >
+                                <IoCopyOutline className="w-4 h-4" />
+                                {voucherRefModal}
+                            </button>
+                            <p className="text-[11px] text-gray-400 mt-3">
+                                You&apos;ll need this to download your certificates.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkPaymentModal.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkPaymentModal.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import {
+    IoCardOutline,
+    IoLockClosedOutline,
+    IoMail,
+    IoShieldCheckmarkOutline,
+} from 'react-icons/io5'
+import { isValidEmail } from '@/lib/utils'
+import { formatNaira, type BulkExamConfig } from './examConfig'
+import type { BulkSelectionSummary } from './types'
+import {
+    useSetBecePaymentEmailMutation,
+    useSetUbeatPaymentEmailMutation,
+} from '@/app/result-checking/store/api/studentApi'
+
+interface BulkPaymentModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    config: BulkExamConfig
+    summary: BulkSelectionSummary
+    schoolName: string
+    /**
+     * Called when the agent confirms payment.
+     * The parent POSTs to `/result-payment/create-batch`, sets
+     * `window.location.href = response.authorizationUrl`, and returns the
+     * payment reference (or `undefined` on failure).
+     *
+     * On success the parent will redirect to Paystack; the modal stays
+     * mounted during the brief navigation window so the agent can't
+     * double-click the pay button. On failure the parent returns
+     * `undefined` and the modal resets its submitting state.
+     */
+    onConfirm: (args: { email: string }) => Promise<string | undefined>
+}
+
+/**
+ * Confirmation + receipt-email modal shown before redirecting to Paystack.
+ *
+ * Mirrors the Paywall's `EmailDialog` pattern exactly:
+ *   1. Validate the email
+ *   2. Call `onConfirm({ email })` (parent: createBatchPayment + redirect)
+ *   3. After the parent returns the reference, PATCH the email onto the
+ *      payment using the same `setBecePaymentEmail` / `setUbeatPaymentEmail`
+ *      mutations used by the single-student Paywalls
+ *   4. The email PATCH races the redirect — that's a known characteristic
+ *      of the existing flow, not a bug
+ *
+ * **Sticky loading rule**: once `isSubmitting` is true, it is ONLY reset
+ * on a failure path. A successful `onConfirm` (or successful email set)
+ * leaves `isSubmitting = true` so the Pay button stays disabled until the
+ * page navigation tears the modal down. This prevents the agent from
+ * clicking "Pay" twice and creating two Paystack transactions.
+ */
+export default function BulkPaymentModal({
+    open,
+    onOpenChange,
+    config,
+    summary,
+    schoolName,
+    onConfirm,
+}: BulkPaymentModalProps) {
+    const [email, setEmail] = useState('')
+    const [error, setError] = useState<string | null>(null)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    const [setBecePaymentEmail] = useSetBecePaymentEmailMutation()
+    const [setUbeatPaymentEmail] = useSetUbeatPaymentEmailMutation()
+
+    useEffect(() => {
+        if (open) {
+            setEmail('')
+            setError(null)
+            setIsSubmitting(false)
+            setTimeout(() => inputRef.current?.focus(), 60)
+        }
+    }, [open])
+
+    const handleConfirm = async () => {
+        const trimmed = email.trim()
+
+        if (!trimmed) {
+            setError('Please enter an email for the receipt.')
+            return
+        }
+        if (!isValidEmail(trimmed)) {
+            setError('That doesn\'t look like a valid email address.')
+            return
+        }
+
+        setError(null)
+        // ── Sticky loading: set true ONCE here. From this point on, the
+        // Pay and Cancel buttons are disabled and will not re-enable
+        // until a failure path explicitly resets the state. A successful
+        // `onConfirm` (which triggers window.location.href) does NOT
+        // reset isSubmitting — the modal will be unmounted by the page
+        // navigation before the user ever sees it re-enable.
+        setIsSubmitting(true)
+
+        try {
+            const reference = await onConfirm({ email: trimmed })
+            if (!reference) {
+                // createBatchPayment failed — the parent has already
+                // reset its own loading state and toasted the error.
+                // Re-enable the modal so the agent can retry.
+                setError('Couldn\'t start the payment. Please try again.')
+                setIsSubmitting(false)
+                return
+            }
+
+            // createBatchPayment succeeded and the parent has already
+            // set `window.location.href = response.authorizationUrl`.
+            // PATCH the email onto the payment, racing the redirect.
+            //
+            // ── Sticky loading: the email PATCH happens AFTER the
+            // redirect has been triggered. We do NOT want a PATCH
+            // failure to reset isSubmitting (which would re-enable the
+            // Pay button mid-navigation and could cause a duplicate
+            // payment if the user clicked it again before the page
+            // tears down). The PATCH is best-effort: log the failure
+            // and let the navigation continue.
+            try {
+                const setEmail = config.examType === 'bece' ? setBecePaymentEmail : setUbeatPaymentEmail
+                const result = await setEmail({
+                    email: trimmed,
+                    paymentReference: reference,
+                }).unwrap()
+
+                // Paywall's existing check: any status >= 201 is treated
+                // as a hard error (mirrors the single-student EmailDialog).
+                if (typeof result.status === 'number' && result.status >= 201) {
+                    throw new Error('Email could not be saved on the payment')
+                }
+            } catch (emailErr) {
+                console.warn(
+                    'Receipt email could not be saved on the payment, but the Paystack redirect is already in progress.',
+                    emailErr,
+                )
+                // Intentionally NOT resetting isSubmitting — the page is
+                // about to navigate. The agent will not be able to click
+                // Pay again before the modal is unmounted.
+            }
+
+            // Success: isSubmitting STAYS true. The page navigation will
+            // unmount the modal shortly.
+        } catch (err) {
+            // This catch only fires for the createBatchPayment path (the
+            // email PATCH has its own try/catch above). Reset isSubmitting
+            // so the agent can retry.
+            console.error('Bulk payment confirmation failed', err)
+            setError('Something went wrong. Please try again.')
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={isSubmitting ? undefined : onOpenChange}>
+            <DialogContent className="sm:max-w-md rounded-2xl p-0 overflow-hidden gap-0">
+                <div className="h-1.5 w-full bg-gradient-to-r from-green-500 to-green-600" />
+
+                <div className="p-6">
+                    <DialogHeader className="mb-5">
+                        <div className="flex items-center justify-center w-12 h-12 rounded-full bg-green-50 border border-green-100 mb-4 mx-auto">
+                            <IoCardOutline className="w-6 h-6 text-green-600" aria-hidden="true" />
+                        </div>
+                        <DialogTitle className="text-center text-lg font-semibold text-gray-900">
+                            Confirm bulk payment
+                        </DialogTitle>
+                        <DialogDescription className="text-sm text-gray-500 text-center mt-1 leading-relaxed">
+                            You&apos;re about to pay for {summary.payableCount} {config.shortName}
+                            {' '}result{summary.payableCount === 1 ? '' : 's'} at <span className="capitalize">{schoolName.toLowerCase()}</span>.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {/* Receipt summary */}
+                    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-5 space-y-2.5">
+                        <Row label="Exam" value={config.shortName} />
+                        <Row label="Results to pay for" value={`${summary.payableCount}`} />
+                        <Row label="Price per result" value={formatNaira(config.pricePerStudent)} />
+                        <div className="h-px bg-gray-200 my-2" />
+                        <Row
+                            label="Total amount"
+                            value={formatNaira(summary.totalAmount)}
+                            emphasised
+                        />
+                    </div>
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="bulk-payment-email"
+                            className="block text-sm font-medium text-gray-700 mb-1.5"
+                        >
+                            Receipt email
+                        </label>
+                        <div className="relative">
+                            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <IoMail
+                                    className={`h-5 w-5 transition-colors ${error ? 'text-red-400' : 'text-gray-400'}`}
+                                    aria-hidden="true"
+                                />
+                            </div>
+                            <input
+                                ref={inputRef}
+                                id="bulk-payment-email"
+                                type="email"
+                                value={email}
+                                onChange={(e) => {
+                                    setEmail(e.target.value)
+                                    if (error) setError(null)
+                                }}
+                                placeholder="agent@example.com"
+                                autoComplete="email"
+                                disabled={isSubmitting}
+                                className={[
+                                    'block w-full pl-10 pr-3 py-2.5 text-sm border rounded-lg',
+                                    'focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-colors',
+                                    error ? 'border-red-300 bg-red-50' : 'border-gray-300 hover:border-green-400',
+                                ].join(' ')}
+                            />
+                        </div>
+                        {error && (
+                            <p className="text-xs text-red-600 mt-1.5">{error}</p>
+                        )}
+                        <p className="text-[11px] text-gray-500 mt-1.5 flex items-center gap-1">
+                            <IoShieldCheckmarkOutline className="w-3 h-3" />
+                            We&apos;ll send your bulk receipt and ZIP download link here.
+                        </p>
+                    </div>
+
+                    <DialogFooter className="sm:justify-between gap-2">
+                        <button
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                            disabled={isSubmitting}
+                            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleConfirm}
+                            disabled={isSubmitting}
+                            className="inline-flex justify-center items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                    Redirecting…
+                                </>
+                            ) : (
+                                <>
+                                    <IoLockClosedOutline className="w-4 h-4" />
+                                    Pay {formatNaira(summary.totalAmount)}
+                                </>
+                            )}
+                        </button>
+                    </DialogFooter>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+function Row({
+    label,
+    value,
+    emphasised = false,
+}: {
+    label: string
+    value: string
+    emphasised?: boolean
+}) {
+    return (
+        <div className="flex justify-between items-center text-sm">
+            <span className={emphasised ? 'text-gray-700 font-medium' : 'text-gray-500'}>
+                {label}
+            </span>
+            <span
+                className={[
+                    'text-right',
+                    emphasised ? 'text-base font-bold text-green-700' : 'text-gray-900 font-medium',
+                ].join(' ')}
+            >
+                {value}
+            </span>
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkResultsToolbar.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkResultsToolbar.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import React from 'react'
+import { IoClose, IoSearch } from 'react-icons/io5'
+import type { BulkStatusFilter } from './types'
+
+interface BulkResultsToolbarProps {
+    /** Current search input (free-text matches against `studentName`). */
+    searchQuery: string
+    onSearchChange: (value: string) => void
+    /** Active status filter chip. */
+    statusFilter: BulkStatusFilter
+    onStatusFilterChange: (value: BulkStatusFilter) => void
+    /** Total cohort size across all pages (the "All" chip count). */
+    totalCount: number
+    /** Cohort size after applying the status filter (the active chip count). */
+    filteredCount: number
+    /** Cohort size after applying both the status filter and the search. */
+    matchingCount: number
+    /** Whether the chips are interactive. */
+    disabled?: boolean
+}
+
+interface ChipDef {
+    key: BulkStatusFilter
+    label: string
+}
+
+const STATUS_CHIPS: readonly ChipDef[] = [
+    { key: 'all', label: 'All' },
+    { key: 'unpaid', label: 'Unpaid' },
+    { key: 'paid', label: 'Paid' },
+] as const
+
+/**
+ * Toolbar mounted above the bulk results table.
+ *
+ *   [ search ] [ All 340 | Unpaid 340 | Paid 0 ]
+ *
+ * The agent selects rows with the per-row checkboxes. There is no
+ * "Select all" affordance — the server caps the response at the page
+ * size, so any "select all" button that fetched in one call would be
+ * a lie. The agent works one page at a time and accumulates selections
+ * across pages via the cross-page `selectedIds` set.
+ */
+export default function BulkResultsToolbar({
+    searchQuery,
+    onSearchChange,
+    statusFilter,
+    onStatusFilterChange,
+    totalCount,
+    filteredCount,
+    matchingCount,
+    disabled = false,
+}: BulkResultsToolbarProps) {
+    // Per-chip counts for the badge. "Unpaid" and "Paid" show the filtered
+    // count when active (so the chip matches the visible list), and 0
+    // otherwise — the actual breakdown is computed by the parent and the
+    // exact value is shown in the "X of Y match" caption.
+    const chipCount = (key: BulkStatusFilter): number => {
+        if (key === 'all') return totalCount
+        if (statusFilter === key) return filteredCount
+        return 0
+    }
+
+    return (
+        <div className="px-4 sm:px-6 py-3 border-b border-gray-100 bg-gray-50/60 flex flex-col lg:flex-row lg:items-center gap-3">
+            {/* ── Search ──────────────────────────────────────────────── */}
+            <div className="relative flex-1 min-w-0 lg:max-w-sm">
+                <IoSearch className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => onSearchChange(e.target.value)}
+                    placeholder="Search by student name…"
+                    aria-label="Search students"
+                    className="w-full pl-9 pr-9 py-2 text-sm bg-white border border-gray-200 rounded-lg placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-green-500/40 focus:border-green-500 transition-colors"
+                />
+                {searchQuery && (
+                    <button
+                        type="button"
+                        onClick={() => onSearchChange('')}
+                        aria-label="Clear search"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                    >
+                        <IoClose className="w-3.5 h-3.5" />
+                    </button>
+                )}
+            </div>
+
+            {/* ── Status chips ────────────────────────────────────────── */}
+            <div className="inline-flex items-center gap-0.5 bg-white border border-gray-200 rounded-lg p-0.5 self-start lg:self-auto">
+                {STATUS_CHIPS.map(chip => {
+                    const isActive = statusFilter === chip.key
+                    const count = chipCount(chip.key)
+                    return (
+                        <button
+                            key={chip.key}
+                            type="button"
+                            onClick={() => onStatusFilterChange(chip.key)}
+                            disabled={disabled}
+                            className={[
+                                'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all',
+                                'disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer',
+                                isActive
+                                    ? 'bg-green-600 text-white shadow-sm'
+                                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50',
+                            ].join(' ')}
+                        >
+                            <span>{chip.label}</span>
+                            <span
+                                className={[
+                                    'inline-flex items-center justify-center min-w-[1.25rem] px-1 h-4 text-[10px] font-semibold rounded-full tabular-nums',
+                                    isActive
+                                        ? 'bg-white/20 text-white'
+                                        : 'bg-gray-100 text-gray-600',
+                                ].join(' ')}
+                            >
+                                {count}
+                            </span>
+                        </button>
+                    )
+                })}
+            </div>
+
+            {/* ── Spacer + match caption ──────────────────────────────── */}
+            <div className="lg:ml-auto flex items-center gap-2">
+                {searchQuery || statusFilter !== 'all' ? (
+                    <span className="text-[11px] text-gray-500 hidden sm:inline">
+                        {matchingCount === 0
+                            ? 'No matches'
+                            : `${matchingCount} of ${totalCount} match`}
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/BulkSearchForm.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/BulkSearchForm.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { IoBusinessOutline, IoCalendarOutline, IoLocationOutline, IoSearch } from 'react-icons/io5'
+import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
+import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
+import { useGetAvailableYearsQuery } from '@/app/result-checking/store/api/studentApi'
+import { LGA_OPTIONS } from './mockData'
+import type { BulkExamConfig } from './examConfig'
+import type { BulkSearchFilters } from './types'
+
+interface BulkSearchFormProps {
+    config: BulkExamConfig
+    value: BulkSearchFilters
+    onChange: (value: BulkSearchFilters) => void
+    onSubmit: () => void
+    isLoading?: boolean
+    disabled?: boolean
+}
+
+/**
+ * 3-field search form: Year + LGA + School.
+ * Mirrors the alternative-form pattern from the main BECE/UBEAT login:
+ *   - LGA list is the same `LgaEnum`-derived `LGA_OPTIONS` constant
+ *   - Years are pulled live via `useGetAvailableYearsQuery({ examType })`
+ *   - Schools are pulled live via `useGetSchoolNamesQuery({ lga })`
+ *   - Same "select an LGA before schools become available" affordance
+ *   - Same loading + "no data" empty states
+ */
+export default function BulkSearchForm({
+    config,
+    value,
+    onChange,
+    onSubmit,
+    isLoading = false,
+    disabled = false,
+}: BulkSearchFormProps) {
+    // ── Live available years (per exam) ──────────────────────────────────
+    const { data: yearsData, isLoading: isLoadingYears } = useGetAvailableYearsQuery({
+        examType: config.examType,
+    })
+
+    const yearOptions = useMemo(
+        () => (yearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) })),
+        [yearsData],
+    )
+
+    // ── Live school list (LGA-scoped) ────────────────────────────────────
+    const { data: schoolNames, isLoading: isLoadingSchools, isFetching: isFetchingSchools } =
+        useGetSchoolNamesQuery(
+            { lga: value.lga },
+            { skip: !value.lga },
+        )
+
+    const schoolNamesList = useMemo(() => schoolNames ?? [], [schoolNames])
+
+    const schoolOptions = useMemo(
+        () =>
+            schoolNamesList.map(school => ({
+                value: school._id,
+                label: String(school.schoolName).startsWith('"')
+                    ? String(school.schoolName).slice(1)
+                    : school.schoolName,
+            })),
+        [schoolNamesList],
+    )
+
+    const isFormValid =
+        value.examYear.trim().length === 4 &&
+        value.lga.trim().length >= 2 &&
+        value.school.id.trim().length > 0
+
+    const handleLgaChange = (lga: string) => {
+        // Reset school when LGA changes — mirrors the BECE alternative form.
+        onChange({ ...value, lga, school: { id: '', name: '' } })
+    }
+
+    const handleSchoolChange = (schoolId: string) => {
+        const match = schoolNamesList.find(s => s._id === schoolId)
+        onChange({
+            ...value,
+            school: { id: schoolId, name: match?.schoolName ?? '' },
+        })
+    }
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!isFormValid || isLoading || disabled) return
+        onSubmit()
+    }
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            className="bg-white rounded-3xl border border-gray-200 overflow-hidden"
+            aria-label={`Search ${config.shortName} cohort`}
+        >
+            <div className="border-b border-gray-100 px-6 py-4 flex items-center justify-between">
+                <div>
+                    <h3 className="text-sm font-semibold text-gray-900">
+                        Find a {config.shortName} cohort
+                    </h3>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                        Pick a year, LGA and school to load every student in that group.
+                    </p>
+                </div>
+            </div>
+
+            <div className="p-6 grid grid-cols-1 md:grid-cols-3 gap-5">
+                {/* Exam Year */}
+                <div className="group">
+                    <label
+                        htmlFor="bulk-exam-year"
+                        className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2"
+                    >
+                        <IoCalendarOutline className="w-4 h-4 text-gray-400" />
+                        Exam Year <span className="text-red-500">*</span>
+                    </label>
+                    {isLoadingYears ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            <div className="flex items-center gap-2">
+                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+                                <span>Loading years…</span>
+                            </div>
+                        </div>
+                    ) : yearOptions.length === 0 ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            No years available for this exam yet
+                        </div>
+                    ) : (
+                        <CustomDropdown
+                            options={yearOptions}
+                            value={value.examYear}
+                            onChange={year => onChange({ ...value, examYear: year })}
+                            placeholder="Select exam year"
+                        />
+                    )}
+                </div>
+
+                {/* LGA */}
+                <div className="group">
+                    <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2">
+                        <IoLocationOutline className="w-4 h-4 text-gray-400" />
+                        Local Government Area <span className="text-red-500">*</span>
+                    </label>
+                    <CustomDropdown
+                        options={LGA_OPTIONS}
+                        value={value.lga}
+                        onChange={handleLgaChange}
+                        placeholder="Select LGA"
+                        searchable
+                        searchPlaceholder="Search LGA..."
+                    />
+                </div>
+
+                {/* School */}
+                <div className="group">
+                    <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2">
+                        <IoBusinessOutline className="w-4 h-4 text-gray-400" />
+                        School Name <span className="text-red-500">*</span>
+                    </label>
+                    {!value.lga ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            Select an LGA first
+                        </div>
+                    ) : isLoadingSchools || isFetchingSchools ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            <div className="flex items-center gap-2">
+                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+                                <span>Loading {value.lga} schools…</span>
+                            </div>
+                        </div>
+                    ) : schoolOptions.length === 0 ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            No schools available for this LGA
+                        </div>
+                    ) : (
+                        <CustomDropdown
+                            options={schoolOptions}
+                            value={value.school.id}
+                            onChange={handleSchoolChange}
+                            placeholder="Select a school"
+                            searchable
+                            searchPlaceholder="Search school name..."
+                        />
+                    )}
+                </div>
+            </div>
+
+            {/* Submit */}
+            <div className="px-6 pb-6 flex flex-col sm:flex-row items-stretch sm:items-center sm:justify-between gap-3">
+                <p className="text-xs text-gray-500 flex items-center gap-1.5">
+                    <IoSearch className="w-3.5 h-3.5" />
+                    Results are paginated 10 per page. You can change filters at any time.
+                </p>
+                <button
+                    type="submit"
+                    disabled={!isFormValid || isLoading || disabled}
+                    className={[
+                        'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold',
+                        'text-white bg-gray-900 hover:bg-gray-800 transition-colors',
+                        'disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer',
+                    ].join(' ')}
+                >
+                    {isLoading ? (
+                        <>
+                            <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                            Loading cohort…
+                        </>
+                    ) : (
+                        <>
+                            <IoSearch className="w-4 h-4" />
+                            Load cohort
+                        </>
+                    )}
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/EmptyState.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/EmptyState.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import React from 'react'
+import { IoFilterOutline, IoSearchCircleOutline } from 'react-icons/io5'
+import type { BulkStatusFilter } from './types'
+
+interface EmptyStateProps {
+    /** Triggered by the "Try different filters" CTA — used when the *whole* cohort is empty. */
+    onChangeFilters: () => void
+
+    /**
+     * Optional context that unlocks in-place recovery actions. If provided,
+     * `EmptyState` treats the user as "filtered into a dead-end" (the cohort
+     * has data, the user's filter just doesn't match any of it) and offers
+     * buttons to clear the search / switch status / show all without ever
+     * leaving the results screen.
+     */
+    context?: {
+        /** Cohort size before any user-applied filter / search. */
+        totalCohort: number
+        /** Cohort size after the status filter (but before the search). */
+        statusFilteredCount: number
+        /** True if a search query is currently typed in the toolbar. */
+        isSearching: boolean
+        /** Current search query (used in the heading). */
+        searchQuery: string
+        /** Current status filter (used to compute the "switch to other" CTA). */
+        statusFilter: BulkStatusFilter
+        /** Clear the in-table search input. */
+        onClearSearch: () => void
+        /** Set the status filter back to 'all'. */
+        onShowAllStatuses: () => void
+        /** Switch to a specific status filter (e.g. the "other" one). */
+        onSwitchStatus: (status: BulkStatusFilter) => void
+    }
+}
+
+const OTHER_STATUS: Record<Exclude<BulkStatusFilter, 'all'>, BulkStatusFilter> = {
+    unpaid: 'paid',
+    paid: 'unpaid',
+}
+
+const STATUS_LABEL: Record<BulkStatusFilter, string> = {
+    all: 'All',
+    unpaid: 'Unpaid',
+    paid: 'Paid',
+}
+
+/**
+ * Shown when a search has been run but the (filtered) cohort is empty.
+ *
+ * Two distinct presentations:
+ *
+ *   1. **No cohort at all** (`context` absent or `totalCohort === 0`) —
+ *      render a full-card message and a single CTA that takes the user
+ *      back to the search form.
+ *
+ *   2. **Filtered into a dead-end** (`context` present and
+ *      `totalCohort > 0`) — render an in-card message and up to three
+ *      one-click recovery buttons (Show all / Clear search / Switch
+ *      status) so the user can recover without leaving the page.
+ */
+export default function EmptyState({
+    onChangeFilters,
+    context,
+}: EmptyStateProps) {
+    const isFilterDeadEnd = !!context && context.totalCohort > 0
+
+    if (!isFilterDeadEnd) {
+        return (
+            <div className="bg-white rounded-3xl border border-gray-200 px-6 py-12 text-center">
+                <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-amber-50 border border-amber-100 flex items-center justify-center">
+                    <IoSearchCircleOutline className="w-8 h-8 text-amber-500" />
+                </div>
+                <h3 className="text-base font-semibold text-gray-900 mb-2">
+                    No students found for that combination
+                </h3>
+                <p className="text-sm text-gray-600 max-w-md mx-auto mb-6">
+                    This school may not have any approved results for the selected year, or the cohort hasn't been uploaded yet. Try adjusting your filters.
+                </p>
+                <button
+                    type="button"
+                    onClick={onChangeFilters}
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-green-700 bg-green-50 hover:bg-green-100 border border-green-100 transition-colors cursor-pointer"
+                >
+                    Try different filters
+                </button>
+            </div>
+        )
+    }
+
+    // ── Filtered-into-a-dead-end case ────────────────────────────────────
+    const {
+        totalCohort,
+        isSearching,
+        searchQuery,
+        statusFilter,
+        onClearSearch,
+        onShowAllStatuses,
+        onSwitchStatus,
+    } = context!
+
+    const isFilteringByStatus = statusFilter !== 'all'
+    const otherStatus = isFilteringByStatus ? OTHER_STATUS[statusFilter] : null
+    // Every student is either paid or unpaid (see bulkApiAdapter), so the
+    // "other" count is just the complement of the current filtered count.
+    const otherStatusCount = isFilteringByStatus
+        ? totalCohort - context!.statusFilteredCount
+        : 0
+
+    const heading = (() => {
+        if (isSearching && isFilteringByStatus) {
+            return `No ${STATUS_LABEL[statusFilter].toLowerCase()} students match "${searchQuery.trim()}"`
+        }
+        if (isSearching) {
+            return `No students match "${searchQuery.trim()}"`
+        }
+        if (isFilteringByStatus) {
+            return `No ${STATUS_LABEL[statusFilter].toLowerCase()} students in this cohort`
+        }
+        return 'No students to show'
+    })()
+
+    return (
+        <div className="px-6 py-12 text-center">
+            <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-blue-50 border border-blue-100 flex items-center justify-center">
+                <IoFilterOutline className="w-8 h-8 text-blue-500" />
+            </div>
+            <h3 className="text-base font-semibold text-gray-900 mb-2">
+                {heading}
+            </h3>
+            <p className="text-sm text-gray-600 max-w-md mx-auto mb-6">
+                The cohort has <span className="font-semibold text-gray-900">{totalCohort}</span> student{totalCohort === 1 ? '' : 's'} total. Try one of the options below to widen the view.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                    type="button"
+                    onClick={onShowAllStatuses}
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-green-600 hover:bg-green-700 border border-green-600 transition-colors cursor-pointer"
+                >
+                    Show all {totalCohort} student{totalCohort === 1 ? '' : 's'}
+                </button>
+                {isSearching && (
+                    <button
+                        type="button"
+                        onClick={onClearSearch}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 border border-gray-200 transition-colors cursor-pointer"
+                    >
+                        Clear search
+                    </button>
+                )}
+                {otherStatus && otherStatusCount > 0 && (
+                    <button
+                        type="button"
+                        onClick={() => onSwitchStatus(otherStatus)}
+                        title={`Show the ${otherStatusCount} ${STATUS_LABEL[otherStatus].toLowerCase()} student${otherStatusCount === 1 ? '' : 's'} instead`}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 border border-gray-200 transition-colors cursor-pointer"
+                    >
+                        View {otherStatusCount} {STATUS_LABEL[otherStatus].toLowerCase()}
+                    </button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/LoadingState.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/LoadingState.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React from 'react'
+
+interface LoadingStateProps {
+    /** Number of skeleton rows to render — keep close to itemsPerPage. */
+    rows?: number
+}
+
+/**
+ * Skeleton loader styled to match the dimensions of the loaded table,
+ * so the layout doesn't jump once data arrives.
+ */
+export default function LoadingState({ rows = 8 }: LoadingStateProps) {
+    return (
+        <div className="bg-white rounded-3xl border border-gray-200 overflow-hidden">
+            <div className="border-b border-gray-100 px-6 py-4">
+                <div className="h-4 w-48 bg-gray-200 rounded animate-pulse mb-2" />
+                <div className="h-3 w-72 bg-gray-100 rounded animate-pulse" />
+            </div>
+
+            <div className="divide-y divide-gray-100">
+                {Array.from({ length: rows }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-4 px-6 py-4">
+                        <div className="w-4 h-4 rounded bg-gray-200 animate-pulse flex-shrink-0" />
+                        <div className="w-6 h-3 rounded bg-gray-100 animate-pulse flex-shrink-0" />
+
+                        <div className="flex-1 min-w-0 space-y-2">
+                            <div className="h-3 w-1/3 bg-gray-200 rounded animate-pulse" />
+                            <div className="h-2.5 w-1/4 bg-gray-100 rounded animate-pulse" />
+                        </div>
+
+                        <div className="hidden md:block h-3 w-24 bg-gray-100 rounded animate-pulse" />
+                        <div className="hidden md:block h-3 w-12 bg-gray-100 rounded animate-pulse" />
+                        <div className="h-5 w-16 rounded-full bg-gray-100 animate-pulse" />
+                        <div className="hidden sm:block h-6 w-20 rounded-md bg-gray-100 animate-pulse" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/PaymentStatusBadge.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/PaymentStatusBadge.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React from 'react'
+import { IoCheckmarkCircle, IoHourglass, IoAlertCircle } from 'react-icons/io5'
+import type { BulkPaymentStatus } from './types'
+
+interface PaymentStatusBadgeProps {
+    status: BulkPaymentStatus
+    /** Compact variant used inside dense tables. */
+    size?: 'sm' | 'md'
+}
+
+const STATUS_STYLES: Record<BulkPaymentStatus, { icon: React.ReactNode; label: string; className: string }> = {
+    paid: {
+        icon: <IoCheckmarkCircle className="w-3.5 h-3.5" />,
+        label: 'Paid',
+        className: 'bg-green-50 text-green-700 border-green-200',
+    },
+    pending: {
+        icon: <IoHourglass className="w-3.5 h-3.5 animate-pulse" />,
+        label: 'Pending',
+        className: 'bg-amber-50 text-amber-700 border-amber-200',
+    },
+    unpaid: {
+        icon: <IoAlertCircle className="w-3.5 h-3.5" />,
+        label: 'Unpaid',
+        className: 'bg-gray-50 text-gray-600 border-gray-200',
+    },
+}
+
+export default function PaymentStatusBadge({ status, size = 'md' }: PaymentStatusBadgeProps) {
+    const style = STATUS_STYLES[status]
+    return (
+        <span
+            className={[
+                'inline-flex items-center gap-1 rounded-full font-semibold border',
+                size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-xs',
+                style.className,
+            ].join(' ')}
+        >
+            {style.icon}
+            {style.label}
+        </span>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/SearchFilterSummary.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/SearchFilterSummary.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React from 'react'
+import { IoBusinessOutline, IoCalendarOutline, IoLocationOutline, IoPencil } from 'react-icons/io5'
+import type { BulkSearchFilters } from './types'
+
+interface SearchFilterSummaryProps {
+    filters: BulkSearchFilters
+    /** Total students returned by the current filters. */
+    totalItems: number
+    /** Called when the agent clicks "Change filters". */
+    onEdit: () => void
+}
+
+/**
+ * Compact summary card shown above the results table once a search has been run.
+ * Lets the agent see at-a-glance what they're looking at and re-open the form.
+ */
+export default function SearchFilterSummary({
+    filters,
+    totalItems,
+    onEdit,
+}: SearchFilterSummaryProps) {
+    return (
+        <div className="bg-white rounded-2xl border border-gray-200 px-4 py-3 sm:px-6 sm:py-4">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+                    <Pill icon={<IoCalendarOutline className="w-4 h-4" />} label="Year" value={filters.examYear} />
+                    <Pill icon={<IoLocationOutline className="w-4 h-4" />} label="LGA" value={filters.lga} />
+                    <Pill icon={<IoBusinessOutline className="w-4 h-4" />} label="School" value={filters.school.name} truncate />
+                    <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-green-50 text-green-700 text-xs font-semibold border border-green-100">
+                        {totalItems.toLocaleString()} student{totalItems === 1 ? '' : 's'}
+                    </span>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium text-green-700 bg-green-50 hover:bg-green-100 border border-green-100 transition-colors cursor-pointer"
+                >
+                    <IoPencil className="w-3.5 h-3.5" />
+                    Change filters
+                </button>
+            </div>
+        </div>
+    )
+}
+
+function Pill({
+    icon,
+    label,
+    value,
+    truncate = false,
+}: {
+    icon: React.ReactNode
+    label: string
+    value: string
+    truncate?: boolean
+}) {
+    return (
+        <span className="inline-flex items-center gap-2 min-w-0">
+            <span className="flex-shrink-0 text-gray-400">{icon}</span>
+            <span className="flex-shrink-0 text-xs uppercase tracking-wide text-gray-500">{label}</span>
+            <span className={[
+                'text-sm font-semibold text-gray-900 capitalize',
+                truncate ? 'truncate max-w-[200px] sm:max-w-[300px]' : '',
+            ].join(' ')}>
+                {(value || '—').toLowerCase()}
+            </span>
+        </span>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/StudentResultsRow.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/StudentResultsRow.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import React from 'react'
+import PaymentStatusBadge from './PaymentStatusBadge'
+import { toTitleCase } from './format'
+import type { BulkStudent } from './types'
+import type { BulkExamConfig } from './examConfig'
+
+interface StudentResultsRowProps {
+    student: BulkStudent
+    /** Global index across pages — used for serial numbers. */
+    serial: number
+    checked: boolean
+    onToggle: (id: string, event: React.MouseEvent) => void
+    config: BulkExamConfig
+    /** Disable inputs while a bulk action is running. */
+    disabled?: boolean
+}
+
+/**
+ * Single row of the bulk students table.
+ * Renders both as a desktop table row and a mobile card via responsive
+ * Tailwind classes — see `StudentResultsTable` for the desktop wrapper.
+ *
+ * The backend contract (`POST /{examType}/students/by-school`) only returns
+ * `{ _id, name, isPaid }`, so the table is intentionally narrow: serial,
+ * student name, and payment status.
+ */
+export default function StudentResultsRow({
+    student,
+    serial,
+    checked,
+    onToggle,
+    config,
+    disabled = false,
+}: StudentResultsRowProps) {
+    const isPaid = student.paymentStatus === 'paid'
+
+    const handleToggle = (e: React.MouseEvent) => {
+        if (disabled || isPaid) return
+        e.stopPropagation()
+        onToggle(student._id, e)
+    }
+
+    return (
+        <>
+            {/* ── Desktop row ─────────────────────────────────────────── */}
+            <tr
+                className={[
+                    'hidden md:table-row border-b border-gray-100 transition-colors',
+                    isPaid ? 'opacity-50' : checked ? 'bg-green-50/40' : 'hover:bg-gray-50',
+                ].join(' ')}
+            >
+                <td className="px-4 py-3 align-middle">
+                    <label className={isPaid ? 'inline-flex items-center' : 'inline-flex items-center cursor-pointer'}>
+                        <input
+                            type="checkbox"
+                            checked={checked}
+                            onClick={handleToggle}
+                            disabled={disabled || isPaid}
+                            className="w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 disabled:cursor-not-allowed"
+                            aria-label={`Select ${student.studentName}`}
+                        />
+                    </label>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-500 align-middle">{serial}</td>
+                <td className="px-4 py-3 align-middle">
+                    <p className="text-sm font-semibold text-gray-900">
+                        {toTitleCase(student.studentName)}
+                    </p>
+                </td>
+                <td className="px-4 py-3 align-middle">
+                    <PaymentStatusBadge status={student.paymentStatus} />
+                </td>
+            </tr>
+
+            {/* ── Mobile card ─────────────────────────────────────────── */}
+            <tr className="md:hidden">
+                <td colSpan={4} className="px-3 py-2">
+                    <div
+                        className={[
+                            'flex items-start gap-3 p-3 rounded-xl border transition-colors',
+                            isPaid ? 'opacity-50 bg-gray-50 border-gray-200' : checked ? 'bg-green-50/60 border-green-200' : 'bg-white border-gray-200',
+                        ].join(' ')}
+                    >
+                        <input
+                            type="checkbox"
+                            checked={checked}
+                            onClick={handleToggle}
+                            disabled={disabled || isPaid}
+                            className="mt-1 w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 disabled:cursor-not-allowed flex-shrink-0"
+                            aria-label={`Select ${student.studentName}`}
+                        />
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2">
+                                <p className="text-sm font-semibold text-gray-900 truncate">
+                                    {toTitleCase(student.studentName)}
+                                </p>
+                                <PaymentStatusBadge status={student.paymentStatus} size="sm" />
+                            </div>
+                            <p className="text-[11px] text-gray-500 mt-0.5">
+                                #{serial}
+                            </p>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/StudentResultsTable.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/StudentResultsTable.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import React from 'react'
+import StudentResultsRow from './StudentResultsRow'
+import Pagination from '@/app/portal/dashboard/components/Pagination'
+import LoadingState from './LoadingState'
+import EmptyState from './EmptyState'
+import BulkResultsToolbar from './BulkResultsToolbar'
+import type { BulkStatusFilter, BulkStudent } from './types'
+import type { BulkExamConfig } from './examConfig'
+
+interface StudentResultsTableProps {
+    config: BulkExamConfig
+    students: BulkStudent[]
+    selectedIds: Set<string>
+    onToggleOne: (id: string, event: React.MouseEvent) => void
+    isLoading: boolean
+    currentPage: number
+    totalPages: number
+    /** Total cohort size, ignoring search + status filters. */
+    totalItems: number
+    /** Cohort size after the status filter (pre-search). */
+    statusFilteredCount: number
+    /** Cohort size after both status filter + search (== `students.length + offPage`). */
+    matchingCount: number
+    itemsPerPage: number
+    onPageChange: (page: number) => void
+    onItemsPerPageChange: (n: number) => void
+    /** True while a bulk payment / download is in progress. */
+    disabled?: boolean
+    /** Triggered when EmptyState's "Try different filters" CTA is clicked. */
+    onChangeFilters: () => void
+    /** Toolbar props ───────────────────────────────────────────────── */
+    searchQuery: string
+    onSearchChange: (value: string) => void
+    statusFilter: BulkStatusFilter
+    onStatusFilterChange: (value: BulkStatusFilter) => void
+    /** EmptyState context — controls the in-place recovery buttons. */
+    emptyStateContext?: {
+        isSearching: boolean
+        searchQuery: string
+        statusFilter: BulkStatusFilter
+        onClearSearch: () => void
+        onShowAllStatuses: () => void
+        onSwitchStatus: (status: BulkStatusFilter) => void
+    }
+}
+
+/**
+ * Top-level results table.
+ *
+ * Layout invariant: the card chrome (border, header, toolbar) is always
+ * rendered. Only the *body* of the card swaps between three states:
+ *
+ *   1. `<LoadingState>` — initial cohort fetch
+ *   2. `<EmptyState>`   — current filter/search produced zero matches
+ *   3. `<table>`        — happy path, with pagination at the bottom
+ *
+ * Selection is per-row only — the per-page master checkbox was removed
+ * because the server caps the response at the page size, so any "select
+ * all" affordance that didn't fetch additional pages would be a lie.
+ * The agent accumulates selections across pages via the cross-page
+ * `selectedIds` set maintained by the parent.
+ */
+export default function StudentResultsTable({
+    config,
+    students,
+    selectedIds,
+    onToggleOne,
+    isLoading,
+    currentPage,
+    totalPages,
+    totalItems,
+    statusFilteredCount,
+    matchingCount,
+    itemsPerPage,
+    onPageChange,
+    onItemsPerPageChange,
+    disabled = false,
+    onChangeFilters,
+    searchQuery,
+    onSearchChange,
+    statusFilter,
+    onStatusFilterChange,
+    emptyStateContext,
+}: StudentResultsTableProps) {
+    // Cross-page serial numbering — useful when the table spans many pages.
+    const startSerial = (currentPage - 1) * itemsPerPage
+
+    // The toolbar is shown once the cohort is loaded, OR while the user is
+    // actively typing a search / clicking a chip. We don't want to show it
+    // on the very first render before the cohort query has finished.
+    const showToolbar =
+        !isLoading &&
+        (totalItems > 0 || searchQuery !== '' || statusFilter !== 'all')
+
+    const isEmpty = !isLoading && students.length === 0
+
+    return (
+        <div className="bg-white rounded-3xl border border-gray-200 overflow-hidden">
+            {/* Header */}
+            <div className="border-b border-gray-100 px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                    <h3 className="text-sm font-semibold text-gray-900">
+                        Students in this cohort
+                    </h3>
+                    <p className="text-xs text-gray-500 mt-0.5 truncate">
+                        Tick the rows you want to pay for, then use the action bar at the bottom.
+                    </p>
+                </div>
+                <span className="hidden sm:inline-flex text-[11px] text-gray-400 tabular-nums">
+                    {selectedIds.size} selected
+                </span>
+            </div>
+
+            {/* Toolbar (search + status filter chips). */}
+            {showToolbar && (
+                <BulkResultsToolbar
+                    searchQuery={searchQuery}
+                    onSearchChange={onSearchChange}
+                    statusFilter={statusFilter}
+                    onStatusFilterChange={onStatusFilterChange}
+                    totalCount={totalItems}
+                    filteredCount={statusFilteredCount}
+                    matchingCount={matchingCount}
+                    disabled={disabled}
+                />
+            )}
+
+            {/* Body */}
+            {isLoading ? (
+                <LoadingState rows={itemsPerPage} />
+            ) : isEmpty ? (
+                <EmptyState
+                    onChangeFilters={onChangeFilters}
+                    context={
+                        emptyStateContext
+                            ? {
+                                totalCohort: totalItems,
+                                statusFilteredCount,
+                                ...emptyStateContext,
+                            }
+                            : undefined
+                    }
+                />
+            ) : (
+                <>
+                    {/* Table */}
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full">
+                            {/* ── Desktop column headers ─────────────────────── */}
+                            <thead className="hidden md:table-header-group bg-gray-50 border-b border-gray-100">
+                                <tr>
+                                    <th className="px-4 py-3 text-left w-10">
+                                        <span
+                                            className="inline-block w-4 h-4"
+                                            aria-hidden
+                                        />
+                                    </th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide w-12">#</th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide">Student</th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide">Status</th>
+                                </tr>
+                            </thead>
+
+                            {/* ── Mobile header spacer ─────────────────────── */}
+                            <thead className="md:hidden">
+                                <tr>
+                                        <th colSpan={4} className="px-3 py-2 bg-gray-50 border-b border-gray-100 text-[11px] text-gray-500">
+                                            Tick rows to select · {selectedIds.size} selected
+                                        </th>
+                                    </tr>
+                                </thead>
+
+                                <tbody className="md:divide-y md:divide-gray-100">
+                                    {students.map((student, index) => (
+                                        <StudentResultsRow
+                                            key={student._id}
+                                            student={student}
+                                            serial={startSerial + index + 1}
+                                            checked={selectedIds.has(student._id)}
+                                            onToggle={onToggleOne}
+                                            config={config}
+                                            disabled={disabled}
+                                        />
+                                    ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Pagination */}
+                    <div className="px-4 sm:px-6 pt-2 pb-4 border-t border-gray-100">
+                        <Pagination
+                            currentPage={currentPage}
+                            totalPages={totalPages}
+                            itemsPerPage={itemsPerPage}
+                            totalItems={totalItems}
+                            onPageChange={onPageChange}
+                            onItemsPerPageChange={onItemsPerPageChange}
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/VoucherLookup.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/components/VoucherLookup.tsx
@@ -1,0 +1,562 @@
+'use client'
+
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+    IoAlertCircleOutline,
+    IoBusinessOutline,
+    IoCalendarOutline,
+    IoCardOutline,
+    IoCheckmarkCircle,
+    IoChevronDown,
+    IoCopyOutline,
+    IoDownloadOutline,
+    IoHelpCircleOutline,
+    IoLocationOutline,
+    IoLogOutOutline,
+    IoReceiptOutline,
+    IoRefresh,
+    IoSearch,
+} from 'react-icons/io5'
+import toast from 'react-hot-toast'
+import { useLazyGetVoucherQuery, getVoucherDownloadableIds } from '@/app/result-checking/store/api/studentApi'
+import { type BulkExamConfig } from './examConfig'
+import { toTitleCase } from './format'
+import type { VoucherResponse } from '@/app/result-checking/store/api/studentApi'
+
+interface VoucherLookupProps {
+    config: BulkExamConfig
+    initialValue?: string
+    autoFetch?: boolean
+    onDownloadAll: (paidIds: string[], voucher: VoucherResponse) => void
+    onActiveChange?: (active: boolean) => void
+    onVoucherLoaded?: (voucher: VoucherResponse) => void
+    savedVoucher?: VoucherResponse | null
+    verifiedAt?: string | null
+    onClearSaved?: () => void
+}
+
+export default function VoucherLookup({
+    config,
+    initialValue,
+    autoFetch = false,
+    onDownloadAll,
+    onActiveChange,
+    savedVoucher,
+    verifiedAt,
+    onClearSaved,
+    onVoucherLoaded,
+}: VoucherLookupProps) {
+    const [reference, setReference] = useState(initialValue ?? '')
+    const [showHelp, setShowHelp] = useState(false)
+    const [trigger, { data: voucher, isLoading, isError, error, reset }] =
+        useLazyGetVoucherQuery()
+
+    const autoFetchedRef = useRef<string | null>(null)
+
+    const displayVoucher = savedVoucher ?? voucher
+    const isFromStorage = !!savedVoucher
+
+    useEffect(() => {
+        if (initialValue && initialValue !== reference) {
+            setReference(initialValue)
+            reset()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialValue])
+
+    useEffect(() => {
+        if (savedVoucher) return
+        if (
+            autoFetch &&
+            initialValue &&
+            initialValue.trim() &&
+            autoFetchedRef.current !== initialValue
+        ) {
+            autoFetchedRef.current = initialValue
+            trigger(initialValue.trim())
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [autoFetch, initialValue, savedVoucher])
+
+    const downloadableIds = useMemo(() => getVoucherDownloadableIds(displayVoucher), [displayVoucher])
+    const downloadableCount = downloadableIds.length
+    const paidCount = useMemo(
+        () => (displayVoucher?.studentIds ?? []).filter(s => s.isPaid).length,
+        [displayVoucher],
+    )
+
+    const handleSubmit = (e?: React.FormEvent) => {
+        e?.preventDefault()
+        const trimmed = reference.trim()
+        if (!trimmed) {
+            toast.error('Please paste your voucher reference first.')
+            return
+        }
+        autoFetchedRef.current = trimmed
+        trigger(trimmed)
+    }
+
+    useEffect(() => {
+        if (savedVoucher) {
+            onActiveChange?.(true)
+            return
+        }
+        onActiveChange?.(!!(voucher && !isLoading))
+    }, [voucher, isLoading, onActiveChange, savedVoucher])
+
+    useEffect(() => {
+        if (voucher && !savedVoucher && onVoucherLoaded) {
+            onVoucherLoaded(voucher)
+        }
+    }, [voucher, savedVoucher, onVoucherLoaded])
+
+    const handleReset = () => {
+        setReference('')
+        autoFetchedRef.current = null
+        reset()
+        onActiveChange?.(false)
+    }
+
+    const errorMessage =
+        isError && error && typeof error === 'object' && 'data' in error
+            ? (error as { data?: { message?: string } }).data?.message
+            : isError
+                ? (error as { message?: string })?.message ??
+                  "We couldn't find that voucher. Please check the reference and try again."
+                : null
+
+    const copy = async (text: string, label: string) => {
+        try {
+            await navigator.clipboard.writeText(text)
+            toast.success(`${label} copied.`)
+        } catch {
+            toast.error('Could not copy to clipboard.')
+        }
+    }
+
+    const VoucherMetric = ({ count, label, statusText, statusColor, amount }: {
+        count: number; label: string; statusText: string; statusColor: string; amount?: number
+    }) => (
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-5">
+            <div>
+                <div className="flex items-baseline gap-3">
+                    <span className="text-5xl sm:text-7xl font-bold text-gray-900 tracking-tight tabular-nums leading-none">
+                        {count}
+                    </span>
+                    <span className="text-base sm:text-lg text-gray-500 font-medium">
+                        {label}
+                    </span>
+                </div>
+                <div className="flex items-center gap-2 mt-3">
+                    <div className={`w-2 h-2 rounded-full ${statusColor}`} />
+                    <span className="text-sm text-gray-500">{statusText}</span>
+                </div>
+            </div>
+            {amount !== undefined && (
+                <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-gray-50 border border-gray-200">
+                    <div className="text-right">
+                        <p className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">Total paid</p>
+                        <p className="text-xl font-bold text-gray-900 tabular-nums mt-0.5">
+                            ₦{amount.toLocaleString('en-NG')}
+                        </p>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+
+    const VoucherDetails = ({ voucher }: { voucher: VoucherResponse }) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 text-sm">
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoBusinessOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">School</p>
+                    <p className="font-medium text-gray-900 truncate">{toTitleCase(voucher.schoolName)}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoLocationOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">LGA</p>
+                    <p className="font-medium text-gray-900 truncate">{voucher.lga}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoReceiptOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Exam</p>
+                    <p className="font-medium text-gray-900">{voucher.examType} &middot; {voucher.examYear}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoCalendarOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Issued</p>
+                    <p className="font-medium text-gray-900">
+                        {new Date(voucher.createdAt).toLocaleDateString('en-NG', {
+                            year: 'numeric', month: 'short', day: 'numeric',
+                        })}
+                    </p>
+                </div>
+            </div>
+            <div className="sm:col-span-2 flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoCardOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Voucher reference</p>
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => copy(voucher.voucherReference, 'Voucher reference')}
+                            className="group inline-flex items-center gap-1.5"
+                            title="Click to copy"
+                        >
+                            <span className="font-mono text-sm font-medium text-gray-900 truncate">
+                                {voucher.voucherReference}
+                            </span>
+                            <IoCopyOutline className="w-3.5 h-3.5 text-gray-400 group-hover:text-gray-900 transition-colors flex-shrink-0" />
+                        </button>
+                        {voucher.paymentReference && (
+                            <>
+                                <span className="text-gray-300 mx-1">&middot;</span>
+                                <button
+                                    type="button"
+                                    onClick={() => copy(voucher.paymentReference, 'Payment reference')}
+                                    className="group inline-flex items-center gap-1.5"
+                                    title="Click to copy"
+                                >
+                                    <span className="font-mono text-xs text-gray-500 truncate">
+                                        {voucher.paymentReference}
+                                    </span>
+                                    <IoCopyOutline className="w-3 h-3 text-gray-300 group-hover:text-gray-900 transition-colors flex-shrink-0" />
+                                </button>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+
+    const StudentList = ({ voucher }: { voucher: VoucherResponse }) => (
+        <div>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold text-gray-900">Students included</h3>
+                <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full font-medium">
+                    {downloadableCount} {downloadableCount === 1 ? 'student' : 'students'}
+                </span>
+            </div>
+            <div className="border border-gray-100 rounded-xl overflow-hidden divide-y divide-gray-100">
+                {voucher.studentIds
+                    .filter(s => s.isPaid)
+                    .map((s, i) => (
+                        <div key={s._id} className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50/80 transition-colors">
+                            <span className="text-xs text-gray-400 tabular-nums font-medium w-6 text-right flex-shrink-0">
+                                {String(i + 1).padStart(2, '0')}
+                            </span>
+                            <div className="flex-1 min-w-0">
+                                <p className="text-gray-900 truncate font-medium">
+                                    {s.studentName || (
+                                        <span className="italic text-gray-400 font-normal">Name unavailable</span>
+                                    )}
+                                </p>
+                            </div>
+                            <span className="text-[11px] text-gray-400 font-mono">{s._id.slice(-8)}</span>
+                        </div>
+                    ))}
+            </div>
+        </div>
+    )
+
+    const DownloadSection = ({ count, voucher }: { count: number; voucher: VoucherResponse }) => (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+                <p className="text-sm font-semibold text-gray-900">
+                    Download all {count} {count === 1 ? 'certificate' : 'certificates'}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">Saves as a single .zip file</p>
+            </div>
+            <button
+                type="button"
+                onClick={() => onDownloadAll(downloadableIds, voucher)}
+                className="inline-flex items-center justify-center gap-2 h-11 px-6 rounded-xl text-sm font-semibold bg-gray-900 text-white hover:bg-gray-800 active:scale-[0.97] transition-all cursor-pointer"
+            >
+                <IoDownloadOutline className="w-4 h-4" />
+                <span>Download ZIP</span>
+            </button>
+        </div>
+    )
+
+    // ── Render: saved voucher mode ──
+    if (isFromStorage && displayVoucher) {
+        const voucher = displayVoucher
+        return (
+            <section aria-label="Voucher receipt" className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+                {/* Header */}
+                <div className="px-6 sm:px-10 pt-8 sm:pt-10 pb-2 flex items-start justify-between gap-4">
+                    <div>
+                        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+                            Your certificates are ready
+                        </h1>
+                        <p className="mt-1.5 text-sm sm:text-base text-gray-500">
+                            Download your paid {config.certificateLabel.toLowerCase()} certificates below.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClearSaved}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors cursor-pointer flex-shrink-0"
+                        title="Clear saved voucher"
+                    >
+                        <IoLogOutOutline className="w-4 h-4" />
+                        <span className="hidden sm:inline">Clear</span>
+                    </button>
+                </div>
+
+                {/* Success banner */}
+                {verifiedAt && (
+                    <div className="mx-6 sm:mx-10 mt-6 rounded-xl bg-green-50 border border-green-200 overflow-hidden">
+                        <div className="h-1 w-full bg-green-500" />
+                        <div className="p-5 flex items-start gap-4">
+                            <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+                                <IoCheckmarkCircle className="w-5 h-5 text-green-700" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <h3 className="text-sm font-semibold text-green-900">Payment confirmed!</h3>
+                                <p className="text-sm text-green-700 mt-0.5 leading-relaxed">
+                                    Your payment of{' '}
+                                    <span className="font-medium">₦{voucher.amountPaid.toLocaleString('en-NG')}</span>
+                                    {' '}for {voucher.studentCount} {voucher.studentCount === 1 ? 'student' : 'students'}{' '}
+                                    was successful. Your certificates are ready to download.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* Metric */}
+                <div className="px-6 sm:px-10 pt-8 pb-6">
+                    <VoucherMetric
+                        count={downloadableCount}
+                        label={downloadableCount === 1 ? 'certificate' : 'certificates'}
+                        statusText="Ready to download"
+                        statusColor="bg-green-500"
+                        amount={voucher.amountPaid}
+                    />
+                </div>
+
+                {/* Voucher details */}
+                <div className="px-6 sm:px-10 py-6 border-t border-gray-100">
+                    <VoucherDetails voucher={voucher} />
+                </div>
+
+                {/* Students list */}
+                {downloadableCount > 0 && (
+                    <div className="px-6 sm:px-10 pb-6">
+                        <StudentList voucher={voucher} />
+                    </div>
+                )}
+
+                {/* Download CTA */}
+                {downloadableCount > 0 && (
+                    <div className="px-6 sm:px-10 py-6 border-t border-gray-100">
+                        <DownloadSection count={downloadableCount} voucher={voucher} />
+                    </div>
+                )}
+            </section>
+        )
+    }
+
+    // ── Render: normal flow (input form + optional fetch results) ──
+    return (
+        <section aria-label="Voucher receipt" className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+            {/* Header */}
+            <div className="px-6 sm:px-10 pt-8 sm:pt-10 pb-2">
+                <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+                    Download your certificates
+                </h1>
+                <p className="mt-1.5 text-sm sm:text-base text-gray-500">
+                    Paste your voucher reference below to get every paid{' '}
+                    {config.certificateLabel.toLowerCase()} in one ZIP file.
+                </p>
+            </div>
+
+            {/* Input row */}
+            <form onSubmit={handleSubmit} aria-label="Voucher lookup" className="px-6 sm:px-10 pt-6 pb-2">
+                <div className="flex flex-col sm:flex-row gap-2">
+                    <div className="relative flex-1 min-w-0">
+                        <IoSearch
+                            aria-hidden
+                            className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                        />
+                        <input
+                            type="text"
+                            inputMode="text"
+                            autoComplete="off"
+                            spellCheck={false}
+                            value={reference}
+                            onChange={e => setReference(e.target.value)}
+                            placeholder="VCH-XXXXXXXXXX-XXXX"
+                            disabled={isLoading}
+                            aria-label="Voucher reference"
+                            className={[
+                                'w-full h-11 pl-10 pr-4 text-sm rounded-xl border bg-white transition-colors font-mono',
+                                'placeholder:text-gray-300 placeholder:font-sans',
+                                'focus:outline-none focus:ring-2 focus:ring-offset-0',
+                                'disabled:bg-gray-50 disabled:cursor-not-allowed',
+                                isError
+                                    ? 'border-red-300 text-red-900 focus:border-red-500 focus:ring-red-500/20'
+                                    : 'border-gray-300 text-gray-900 focus:border-gray-900 focus:ring-gray-900/10',
+                            ].join(' ')}
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={isLoading || !reference.trim()}
+                        className={[
+                            'inline-flex items-center justify-center gap-2 h-11 px-5 rounded-xl text-sm font-semibold transition-all',
+                            'bg-gray-900 text-white hover:bg-gray-800 cursor-pointer',
+                            'disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed',
+                            !isLoading && reference.trim() ? 'active:scale-[0.97]' : '',
+                        ].join(' ')}
+                    >
+                        {isLoading ? (
+                            <>
+                                <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                <span>Finding your certificates&hellip;</span>
+                            </>
+                        ) : (
+                            <span>Get my certificates</span>
+                        )}
+                    </button>
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1.5 text-xs text-gray-500">
+                    <span>
+                        Format:{' '}
+                        <span className="font-mono text-gray-700 font-medium">VCH-XXXXXXXXXX-XXXX</span>
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => setShowHelp(s => !s)}
+                        aria-expanded={showHelp}
+                        className="inline-flex items-center gap-1 text-gray-600 hover:text-gray-900 cursor-pointer font-medium"
+                    >
+                        <IoHelpCircleOutline className="w-3.5 h-3.5" />
+                        <span>Where do I find this?</span>
+                        <IoChevronDown
+                            className={[
+                                'w-3 h-3 transition-transform duration-200',
+                                showHelp ? 'rotate-180' : '',
+                            ].join(' ')}
+                        />
+                    </button>
+                    {(voucher || isError) && !isLoading && (
+                        <button
+                            type="button"
+                            onClick={handleReset}
+                            className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-900 cursor-pointer font-medium"
+                        >
+                            <IoRefresh className="w-3 h-3" />
+                            <span>Use a different voucher</span>
+                        </button>
+                    )}
+                </div>
+
+                {showHelp && (
+                    <div className="mt-3 px-4 py-3 rounded-xl bg-gray-50 border border-gray-200 text-xs text-gray-600 leading-relaxed space-y-1.5">
+                        <p>
+                            After you pay, we send a receipt email with your voucher reference.
+                            It also appears on the payment success page.
+                        </p>
+                        <p>
+                            The reference always starts with{' '}
+                            <span className="font-mono font-medium text-gray-900">VCH-</span>{' '}
+                            followed by numbers.
+                        </p>
+                        <p>
+                            Can&apos;t find it? Check your email inbox (and spam folder), or
+                            contact support.
+                        </p>
+                    </div>
+                )}
+            </form>
+
+            {/* Error banner */}
+            {isError && (
+                <div className="mx-6 sm:mx-10 mt-6 flex items-start gap-3 px-4 py-3 rounded-xl bg-red-50 border border-red-100">
+                    <IoAlertCircleOutline className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-red-900">
+                            We couldn&apos;t find that voucher.
+                        </p>
+                        <p className="text-xs text-red-700 mt-0.5 leading-relaxed">{errorMessage}</p>
+                    </div>
+                </div>
+            )}
+
+            {/* Fetched voucher success */}
+            {voucher && !isLoading && (
+                <div className="px-6 sm:px-10 pt-8 pb-10 mt-6 border-t border-gray-100 space-y-8">
+                    <VoucherMetric
+                        count={downloadableCount}
+                        label={downloadableCount === 1 ? 'certificate' : 'certificates'}
+                        statusText={
+                            paidCount < voucher.studentCount
+                                ? `${voucher.studentCount - paidCount} still being prepared`
+                                : 'Ready to download'
+                        }
+                        statusColor={paidCount < voucher.studentCount ? 'bg-amber-500' : 'bg-green-500'}
+                        amount={voucher.amountPaid}
+                    />
+
+                    <div className="border-t border-gray-100 pt-6">
+                        <VoucherDetails voucher={voucher} />
+                    </div>
+
+                    {downloadableCount > 0 && (
+                        <StudentList voucher={voucher} />
+                    )}
+
+                    {paidCount === 0 && voucher.studentCount > 0 && (
+                        <div className="px-4 py-4 rounded-xl bg-amber-50 border border-amber-100 text-sm text-amber-900 flex items-start gap-3">
+                            <IoAlertCircleOutline className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+                            <div className="flex-1 min-w-0">
+                                <p className="font-semibold">Your certificates are being prepared.</p>
+                                <p className="text-xs mt-1 text-amber-800 leading-relaxed">
+                                    This voucher covers {voucher.studentCount}{' '}
+                                    {voucher.studentCount === 1 ? 'student' : 'students'}, but
+                                    the certificates aren&apos;t quite ready yet &mdash; the system
+                                    usually finishes within a few seconds.
+                                </p>
+                                <button
+                                    type="button"
+                                    onClick={() => trigger(voucher.voucherReference)}
+                                    className="mt-2.5 inline-flex items-center gap-1.5 text-xs font-medium text-amber-900 hover:text-amber-950 cursor-pointer"
+                                >
+                                    <IoRefresh className="w-3.5 h-3.5" />
+                                    <span>Check again</span>
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    {downloadableCount > 0 && (
+                        <div className="border-t border-gray-100 pt-6">
+                            <DownloadSection count={downloadableCount} voucher={voucher} />
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    )
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/bulkApiAdapter.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/bulkApiAdapter.ts
@@ -1,0 +1,42 @@
+/**
+ * Adapters that map the minimal backend contract to the wider `BulkStudent`
+ * type used by the table UI.
+ *
+ * The `/ubeat/students/by-school` and `/bece/students/by-school` endpoints
+ * only return `{ _id, name, isPaid }` — the table UI may want richer info
+ * (e.g. school name in the modal), so we fold in the request context here.
+ */
+
+import type { BulkStudentListItem } from '@/app/result-checking/store/api/studentApi'
+import type { BulkStudent } from './types'
+
+interface MapContext {
+    schoolId: string
+    schoolName: string
+    lga: string
+    examYear: string | number
+}
+
+/**
+ * Convert one row of the API response into the `BulkStudent` shape used
+ * by the table. Fields not in the contract (examNo, class, gender…) are
+ * intentionally left undefined — the row component renders `—` in that case.
+ */
+export function mapBulkStudentListItem(
+    item: BulkStudentListItem,
+    ctx: MapContext,
+): BulkStudent {
+    const isPaid = Boolean(item.isPaid)
+    const yearNum = typeof ctx.examYear === 'string' ? Number(ctx.examYear) : ctx.examYear
+
+    return {
+        _id: item._id,
+        studentName: item.name,
+        paymentStatus: isPaid ? 'paid' : 'unpaid',
+        certificateReady: isPaid,
+        schoolId: ctx.schoolId,
+        schoolName: ctx.schoolName,
+        lga: ctx.lga,
+        examYear: Number.isFinite(yearNum) ? yearNum : undefined,
+    }
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/examConfig.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/examConfig.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-exam configuration for the Bulk Downloads pages.
+ *
+ * Both `/bulk-downloads/bece` and `/bulk-downloads/ubeat` share the exact same
+ * UI (`BulkPageContent`); only the labels, pricing, certificate name and
+ * (future) mutation hooks differ. This file is the single source of truth for
+ * those differences so adding a third exam later is a one-line change.
+ */
+
+import type { BulkExamType } from './types'
+
+export interface BulkExamConfig {
+    examType: BulkExamType
+    /** Short label used in headings & buttons — e.g. "BECE". */
+    shortName: string
+    /** Long, accessible label used in <abbr title="..."> tooltips. */
+    fullName: string
+    /** Page-level subtitle shown beside the logo. */
+    subtitle: string
+    /** Naira amount per certificate. Displayed and used for total calculation. */
+    pricePerStudent: number
+    /** What the certificate is called on this exam (used in modals + ZIP name). */
+    certificateLabel: string
+    /** Prefix for the downloaded ZIP file. */
+    zipFilenamePrefix: string
+    /** Route to the public single-student page (used as fallback link). */
+    singleStudentRoute: string
+    /** Route this bulk-downloads variant lives at. */
+    bulkRoute: string
+}
+
+export const BULK_EXAM_CONFIGS: Record<BulkExamType, BulkExamConfig> = {
+    bece: {
+        examType: 'bece',
+        shortName: 'BECE',
+        fullName: 'Basic Education Certificate Examination',
+        subtitle: 'Bulk Certificate Downloads · Agent View',
+        pricePerStudent: 1000,
+        certificateLabel: 'BECE Certificate',
+        zipFilenamePrefix: 'BECE_Certificates',
+        singleStudentRoute: '/result-checking/bece',
+        bulkRoute: '/result-checking/bece/bulk-downloads',
+    },
+    ubeat: {
+        examType: 'ubeat',
+        shortName: 'UBEAT',
+        fullName: 'Universal Basic Education Assessment Test',
+        subtitle: 'Bulk FSLC Downloads · Agent View',
+        pricePerStudent: 500,
+        certificateLabel: 'FSLC (UBEAT)',
+        zipFilenamePrefix: 'UBEAT_FSLC_Certificates',
+        singleStudentRoute: '/result-checking/ubeat',
+        bulkRoute: '/result-checking/ubeat/bulk-downloads',
+    },
+}
+
+/** Convenience: format a Naira amount the same way everywhere. */
+export const formatNaira = (amount: number): string =>
+    new Intl.NumberFormat('en-NG', {
+        style: 'currency',
+        currency: 'NGN',
+        minimumFractionDigits: 0,
+    }).format(amount)

--- a/src/app/result-checking/bece/bulk-downloads/components/format.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/format.ts
@@ -1,0 +1,21 @@
+/**
+ * Small formatting helpers used across the bulk-downloads UI.
+ */
+
+/**
+ * Convert a string to Title Case while keeping common name punctuation
+ * (spaces, hyphens, periods) intact.
+ *
+ *   "ABASURUM FLORA CHIJINDU"     → "Abasurum Flora Chijindu"
+ *   "NNAH-OFORJI IFECHUKWU"      → "Nnah-Oforji Ifechukwu"
+ *   "CHIDIEBUBE O."              → "Chidiebube O."
+ *   "AKWILAM NMESOMA SARAH"      → "Akwilam Nmesoma Sarah"
+ *
+ * Non-letter characters (periods, commas, digits) are preserved as-is.
+ */
+export function toTitleCase(value: string): string {
+    if (!value) return value
+    return value
+        .toLowerCase()
+        .replace(/(^|[\s-])\p{L}/gu, match => match.toUpperCase())
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/mockData.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/mockData.ts
@@ -1,0 +1,19 @@
+/**
+ * Constants for the Bulk Downloads search form.
+ *
+ * Both the available years and the LGA-→-school cascade are now pulled
+ * live via RTK Query:
+ *   - Years  → `useGetAvailableYearsQuery({ examType })`
+ *   - Schools → `useGetSchoolNamesQuery({ lga })`
+ *
+ * Only the static list of LGAs (derived from the shared `LgaEnum`) lives
+ * here, since the enum is the single source of truth across the portal.
+ */
+
+import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
+
+/** LGA options (mirrors `LgaEnum` from the portal types). */
+export const LGA_OPTIONS = Object.values(LgaEnum).map(lga => ({
+    value: lga,
+    label: lga,
+}))

--- a/src/app/result-checking/bece/bulk-downloads/components/types.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared types for the Bulk Result Downloads (Agent) flow.
+ *
+ * The shape of `BulkStudent` is intentionally a superset of the backend
+ * contract (`{ _id, name, isPaid }` — see `BulkStudentListItem` in
+ * `studentApi.ts`). Richer fields are marked optional so the same type
+ * works for both the live API response and a future detailed view fetched
+ * via the per-student `getUBEATResult` / `getBECEResult` endpoints.
+ */
+
+export type BulkExamType = 'bece' | 'ubeat'
+
+/** Payment state of a single student in the bulk list. */
+export type BulkPaymentStatus = 'paid' | 'unpaid' | 'pending'
+
+/** A single student row in the bulk-downloads table. */
+export interface BulkStudent {
+    /** Mongo ObjectId — used as the stable React key & for payment mutations. */
+    _id: string
+    /** Full legal name. Sourced from the API's `name` field. */
+    studentName: string
+    /** Tri-state payment status derived from the API's `isPaid: boolean`. */
+    paymentStatus: BulkPaymentStatus
+    /** Convenience mirror of `paymentStatus === 'paid'`. */
+    certificateReady?: boolean
+
+    // ── Optional context fields (not in the bulk-list contract) ──────────
+    /** XX/000/000 — available only after fetching the detailed result. */
+    examNo?: string
+    /** Exam-specific class label (e.g. "JSS3", "Primary 6"). */
+    studentClass?: string
+    gender?: 'male' | 'female' | string
+    examYear?: number
+    /** Display label of the school (already resolved server-side). */
+    schoolName?: string
+    /** Mongo id of the school — useful for sub-queries. */
+    schoolId?: string
+    /** Imo State LGA name (matches LgaEnum). */
+    lga?: string
+}
+
+/** Search filters captured from `BulkSearchForm`. */
+export interface BulkSearchFilters {
+    examYear: string
+    lga: string
+    /** Selected `{ id, name }` so we can display the label without re-querying. */
+    school: { id: string; name: string }
+}
+
+/** Tri-state status filter for the results toolbar chips. */
+export type BulkStatusFilter = 'all' | 'paid' | 'unpaid'
+
+/** Paginated wrapper used internally by the table view. */
+export interface BulkStudentsResponse {
+    data: BulkStudent[]
+    currentPage: number
+    totalPages: number
+    totalItems: number
+}
+
+/**
+ * Local UI state for the bulk action bar.
+ * Calculated from `selectedIds` against the current page of `BulkStudent[]`.
+ */
+export interface BulkSelectionSummary {
+    selectedCount: number
+    payableCount: number      // selected & unpaid
+    downloadableCount: number // selected & paid (cert ready)
+    totalAmount: number       // payableCount * pricePerStudent
+}

--- a/src/app/result-checking/bece/bulk-downloads/components/voucherStorage.ts
+++ b/src/app/result-checking/bece/bulk-downloads/components/voucherStorage.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import type { VoucherResponse } from '@/app/result-checking/store/api/studentApi'
+
+const STORAGE_KEY_PREFIX = 'bulk-voucher-'
+
+let cachedKey: Promise<CryptoKey> | null = null
+
+async function getKey(): Promise<CryptoKey> {
+    if (cachedKey) return cachedKey
+    cachedKey = (async () => {
+        const salt = new TextEncoder().encode('moe-voucher-v1')
+        const keyMaterial = await crypto.subtle.importKey(
+            'raw',
+            new TextEncoder().encode('moe-bulk-download-key-2026'),
+            'PBKDF2',
+            false,
+            ['deriveKey'],
+        )
+        return crypto.subtle.deriveKey(
+            { name: 'PBKDF2', salt, iterations: 100_000, hash: 'SHA-256' },
+            keyMaterial,
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+        )
+    })()
+    return cachedKey
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+    return btoa(binary)
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+    const binary = atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+}
+
+export async function saveVoucherToStorage(examType: string, voucher: VoucherResponse): Promise<void> {
+    try {
+        const key = await getKey()
+        const iv = crypto.getRandomValues(new Uint8Array(12))
+        const data = new TextEncoder().encode(JSON.stringify(voucher))
+        const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data)
+        const combined = new Uint8Array(iv.length + ciphertext.byteLength)
+        combined.set(iv)
+        combined.set(new Uint8Array(ciphertext), iv.length)
+        localStorage.setItem(STORAGE_KEY_PREFIX + examType, uint8ArrayToBase64(combined))
+    } catch (e) {
+        console.error('Failed to save voucher', e)
+    }
+}
+
+export async function loadVoucherFromStorage(examType: string): Promise<VoucherResponse | null> {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + examType)
+        if (!raw) return null
+        const key = await getKey()
+        const combined = base64ToUint8Array(raw)
+        const iv = combined.slice(0, 12)
+        const ciphertext = combined.slice(12)
+        const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+        return JSON.parse(new TextDecoder().decode(decrypted)) as VoucherResponse
+    } catch (e) {
+        console.error('Failed to load voucher', e)
+        localStorage.removeItem(STORAGE_KEY_PREFIX + examType)
+        return null
+    }
+}
+
+export function hasVoucherInStorage(examType: string): boolean {
+    if (typeof window === 'undefined') return false
+    return !!localStorage.getItem(STORAGE_KEY_PREFIX + examType)
+}
+
+export function clearVoucherFromStorage(examType: string): void {
+    localStorage.removeItem(STORAGE_KEY_PREFIX + examType)
+}

--- a/src/app/result-checking/bece/bulk-downloads/page.tsx
+++ b/src/app/result-checking/bece/bulk-downloads/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { studentPortalMetadata } from '@/lib/metadata'
+import BulkPageContent from './components/BulkPageContent'
+import { BULK_EXAM_CONFIGS } from './components/examConfig'
+
+
+export const metadata = studentPortalMetadata.bulkDownloadsBECE
+
+function BulkBECEFallback() {
+    return (
+        <div className="min-h-screen bg-[#F3F3F3] flex items-center justify-center">
+            <div className="animate-spin rounded-full h-10 w-10 border-2 border-green-600 border-t-transparent" />
+        </div>
+    )
+}
+
+export default function BulkBECEDownloadsScreen() {
+    return (
+        <Suspense fallback={<BulkBECEFallback />}>
+            <BulkPageContent config={BULK_EXAM_CONFIGS.bece} />
+        </Suspense>
+    )
+}

--- a/src/app/result-checking/bece/components/PageContent.tsx
+++ b/src/app/result-checking/bece/components/PageContent.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { SessionStore, useSecureSessionStorage } from '@/app/result-checking/utils/secureStorage'
-import { IoPersonCircle, IoLockClosed, IoTrashOutline, IoChevronForward, IoClose, IoChevronDown, IoChevronUp, IoCalendarOutline, IoSwapHorizontal } from 'react-icons/io5'
+import { IoPersonCircle, IoLockClosed, IoTrashOutline, IoChevronForward, IoClose, IoChevronDown, IoChevronUp, IoCalendarOutline, IoSwapHorizontal, IoDownloadOutline } from 'react-icons/io5'
 import toast from 'react-hot-toast'
 import Lottie from 'lottie-react'
 import animationData from '../../assets/students.json'
@@ -833,6 +833,20 @@ export default function StudentLoginPage() {
                                             Don&apos;t know your exam number? Click here
                                         </button>
                                     </div>
+
+                                    <div className="flex items-center gap-3 pt-1">
+                                        <div className="flex-1 h-px bg-gray-100" />
+                                        <span className="text-[10px] uppercase tracking-wider text-gray-400">or</span>
+                                        <div className="flex-1 h-px bg-gray-100" />
+                                    </div>
+
+                                    <Link
+                                        href="/result-checking/bece/bulk-downloads"
+                                        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-200 hover:border-green-300 hover:bg-green-50 hover:text-green-700 transition-all duration-150 cursor-pointer"
+                                    >
+                                        <IoDownloadOutline className="w-4 h-4" />
+                                        Agent? Bulk-download a whole school cohort
+                                    </Link>
                                 </form>
                             )) : matchedStudents ? (
                                 /* ── Student Selection ── */

--- a/src/app/result-checking/bece/dashboard/components/StudentInfoCard.tsx
+++ b/src/app/result-checking/bece/dashboard/components/StudentInfoCard.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
+import { IoDownload } from 'react-icons/io5'
 import { StudentData } from '@/app/result-checking/utils/api'
 
 interface StudentInfoCardProps {
     student: StudentData
+    onDownload?: () => void
+    isDownloading?: boolean
 }
 
-export default function StudentInfoCard({ student }: StudentInfoCardProps) {
+export default function StudentInfoCard({ student, onDownload, isDownloading }: StudentInfoCardProps) {
     return (
         <div className="bg-white rounded-3xl border border-gray-200 overflow-hidden">
             <div className="border-b border-gray-100 px-6 py-4">
@@ -56,6 +59,24 @@ export default function StudentInfoCard({ student }: StudentInfoCardProps) {
                         </p>
                     </div>
                 </div>
+
+                {onDownload && (
+                    <div className="mt-6 pt-5 border-t border-gray-100">
+                        <button
+                            type="button"
+                            onClick={onDownload}
+                            disabled={isDownloading}
+                            className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold bg-green-600 text-white hover:bg-green-700 active:scale-[0.97] transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isDownloading ? (
+                                <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                            ) : (
+                                <IoDownload className="w-4 h-4" />
+                            )}
+                            <span>{isDownloading ? 'Downloading your certificate...' : 'Download Your Certificate'}</span>
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/src/app/result-checking/bece/dashboard/page.tsx
+++ b/src/app/result-checking/bece/dashboard/page.tsx
@@ -449,7 +449,7 @@ export default function StudentDashboardPage() {
                 {/* Content Grid */}
                 <div className="space-y-6 mb-6">
                     {/* Student Info */}
-                    <StudentInfoCard student={student} />
+                    <StudentInfoCard student={student} onDownload={handleDownload} isDownloading={isDownloadingCertificate} />
 
                     {/* Overall Performance Summary */}
                     <div className="bg-white border border-gray-200 rounded-3xl overflow-hidden print:hidden">

--- a/src/app/result-checking/components/SupportWidget.tsx
+++ b/src/app/result-checking/components/SupportWidget.tsx
@@ -985,9 +985,13 @@ function Widget() {
         </>
     );
 
+    const isBulkDownloads = pathName?.includes('bulk-downloads')
+
     return (
         <div className="font-sans">
-            <FAB onClick={() => updateSearchParam("contacting-support", "true")} fabRef={fabRef} />
+            {(!isBulkDownloads || !isMobile) && (
+                <FAB onClick={() => updateSearchParam("contacting-support", "true")} fabRef={fabRef} />
+            )}
 
             {isMobile ? (
                 <BottomSheet open={open} onClose={close} trapRef={panelRef}>

--- a/src/app/result-checking/store/api/apiSlice.ts
+++ b/src/app/result-checking/store/api/apiSlice.ts
@@ -21,7 +21,7 @@ export const apiSlice = createApi({
             return headers
         },
     }),
-    tagTypes: ['School', 'Students'],
+    tagTypes: ['School', 'Students', 'Voucher'],
     endpoints: () => ({}),
 })
 

--- a/src/app/result-checking/store/api/studentApi.ts
+++ b/src/app/result-checking/store/api/studentApi.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '@/app/portal/utils/constants/Api.const'
+import { API_BASE_URL, endpoints } from '@/app/portal/utils/constants/Api.const'
 import { decryptApiResponseFrom, isApiResponseDecryptConfigured } from '@/lib/apiResponseFunnel'
 import { apiSlice } from './apiSlice'
 import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types';
@@ -72,6 +72,326 @@ export interface BECEStudentResult {
     payment?: Payment
     createdAt: string
     updatedAt: string
+}
+
+// ── Bulk Downloads (agent) ────────────────────────────────────────────────
+
+/**
+ * Request body for the bulk students-by-school endpoint.
+ * Mirrors the backend contract: `POST /{ubeat|bece}/students/by-school`.
+ *
+ * All fields — including `page`, `limit`, and `paymentStatus` — are
+ * sent in the POST body (the backend paginates and filters server-side
+ * before responding).
+ */
+export interface BulkStudentsBySchoolRequest {
+    year: number
+    lga: string
+    schoolId: string
+    /** 1-indexed page number. Defaults to 1 server-side. */
+    page?: number
+    /** Items per page. Defaults to a server-side value (we use 25). */
+    limit?: number
+    /** Optional server-side status filter. `undefined` ⇒ no filter (all). */
+    paymentStatus?: 'paid' | 'unpaid'
+}
+
+/**
+ * Pagination metadata returned by the bulk students-by-school endpoint.
+ */
+export interface BulkStudentsPagination {
+    total: number
+    page: number
+    limit: number
+    totalPages: number
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+}
+
+/**
+ * Paginated response from the bulk students-by-school endpoint.
+ *
+ * Real backend shape:
+ * ```
+ * {
+ *   data: BulkStudentListItem[],
+ *   pagination: { total, page, limit, totalPages, hasNextPage, hasPreviousPage }
+ * }
+ * ```
+ */
+export interface BulkStudentsResponse {
+    data: BulkStudentListItem[]
+    pagination: BulkStudentsPagination
+}
+
+/**
+ * One row of the response from the bulk students-by-school endpoint.
+ * The backend intentionally returns a minimal shape — only the fields an
+ * agent needs to make a payment decision and dispatch subsequent calls.
+ * Richer details (examNo, class, gender, subjects) are fetched per-student
+ * from the existing `getUBEATResult` / `getBECEResult` endpoints once a
+ * specific student is opened.
+ */
+export interface BulkStudentListItem {
+    _id: string
+    name: string
+    isPaid: boolean
+}
+
+// ── Bulk Payments (agent) ──────────────────────────────────────────────────
+
+/**
+ * Request body for the batch payment endpoint.
+ * Mirrors the backend contract: `POST /result-payment/create-batch`.
+ *
+ * The `callbackUrl` (sent as a query param) is the URL Paystack will
+ * redirect to after payment. The bulk-downloads page passes its own
+ * route so the agent lands back where they started, with `?reference=...`
+ * in the URL, which triggers the verify effect.
+ */
+export interface CreateBatchPaymentRequest {
+    examType: 'UBEAT' | 'BECE'
+    examYear: number
+    studentIds: string[]
+}
+
+/**
+ * Response from `POST /result-payment/create-batch`.
+ * `authorizationUrl` is the Paystack checkout URL the agent is redirected to.
+ * `reference` is what Paystack (and the backend) use to identify the
+ * transaction; the agent lands back at `callbackUrl?reference=<ref>` after
+ * paying, and we hit `verify-batch` to confirm and refresh the cohort.
+ */
+export interface CreateBatchPaymentResponse {
+    authorizationUrl: string
+    reference: string
+    studentCount: number
+    totalAmount: number
+}
+
+/**
+ * One entry in `paystackResponse.metadata.custom_fields` — Paystack echoes
+ * the variables the backend stored at charge-creation time. The bulk
+ * payment backend stashes `payment_type` (`BATCH_RESULT_PAYMENT`),
+ * `exam_type`, `student_count`, and `exam_year` so the verify response is
+ * self-describing even when the top-level fields are missing.
+ */
+export interface PaystackCustomField {
+    display_name?: string
+    variable_name?: string
+    value?: string
+}
+
+export interface PaystackMetadata {
+    custom_fields?: PaystackCustomField[]
+    referrer?: string
+}
+
+export interface PaystackCustomer {
+    id?: number
+    first_name?: string | null
+    last_name?: string | null
+    email?: string
+    customer_code?: string
+}
+
+export interface PaystackAuthorization {
+    authorization_code?: string
+    bin?: string
+    last4?: string
+    exp_month?: string
+    exp_year?: string
+    channel?: string
+    card_type?: string
+    bank?: string
+    country_code?: string
+    brand?: string
+    reusable?: boolean
+    signature?: string
+    account_name?: string | null
+}
+
+export interface PaystackTransactionLog {
+    time_spent?: number
+    attempts?: number
+    authentication?: string
+    errors?: number
+    success?: boolean
+    mobile?: boolean
+    input?: unknown[]
+    channel?: string
+    metadata?: Record<string, unknown>
+}
+
+export interface PaystackTransaction {
+    id?: number
+    domain?: string
+    status?: string
+    reference?: string
+    receipt_number?: string | null
+    amount?: number
+    message?: string | null
+    gateway_response?: string
+    response_code?: string
+    paid_at?: string
+    created_at?: string
+    channel?: string
+    currency?: string
+    ip_address?: string
+    metadata?: PaystackMetadata
+    log?: PaystackTransactionLog
+    fees?: number | null
+    requested_amount?: number | null
+    transaction_date?: string
+    paidAt?: string
+    createdAt?: string
+    customer?: PaystackCustomer
+    authorization?: PaystackAuthorization
+}
+
+/**
+ * Response from `GET /result-payment/verify/:reference`.
+ *
+ * The backend's `paymentStatus` field drives the success/failed toast and
+ * the cache invalidation. `statusCode === 200` is the legacy fallback for
+ * older backends that wrap the payload. Any other `paymentStatus` value
+ * (`pending`, `abandoned`, etc.) is treated as a failure — the agent is
+ * shown a generic "couldn't verify" toast and the cohort is NOT refreshed.
+ *
+ * The top-level `studentCount` and `totalAmount` are optional — the live
+ * backend instead carries the same numbers inside `paystackResponse`
+ * (kobo-denominated `amount` and `metadata.custom_fields[student_count]`).
+ * Use `getVerifiedStudentCount()` / `getVerifiedTotalAmount()` to read
+ * them portably across both shapes.
+ */
+export interface VerifyBatchPaymentResponse {
+    statusCode?: number
+    paymentStatus: 'successful' | 'failed' | 'pending' | string
+    reference?: string
+    studentCount?: number
+    totalAmount?: number
+    message?: string
+    paystackTransactionId?: string
+    paystackResponse?: PaystackTransaction
+    paymentMethod?: string
+    paymentNotes?: string
+    voucherReference?: string
+}
+
+const PAYSTACK_CUSTOM_FIELD_NAMES = {
+    studentCount: 'student_count',
+    examType: 'exam_type',
+    examYear: 'exam_year',
+    paymentType: 'payment_type',
+} as const
+
+function readPaystackCustomField(
+    response: VerifyBatchPaymentResponse | undefined,
+    variableName: string,
+): string | undefined {
+    const fields = response?.paystackResponse?.metadata?.custom_fields
+    if (!fields) return undefined
+    const match = fields.find(f => f.variable_name === variableName)
+    return match?.value
+}
+
+/**
+ * Pull the student count out of a verify response. Tries top-level
+ * `studentCount` first, then falls back to the Paystack metadata field
+ * (which is where the live backend stores it). Returns `undefined` if
+ * neither is present.
+ */
+export function getVerifiedStudentCount(
+    response: VerifyBatchPaymentResponse | undefined,
+): number | undefined {
+    if (response?.studentCount !== undefined) return response.studentCount
+    const raw = readPaystackCustomField(response, PAYSTACK_CUSTOM_FIELD_NAMES.studentCount)
+    if (raw === undefined) return undefined
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/**
+ * Total paid for the batch, in NAIRA (NOT kobo). Reads from
+ * `paystackResponse.amount` (kobo → naira), with a top-level
+ * `totalAmount` (already in naira) fallback.
+ */
+export function getVerifiedTotalAmountNaira(
+    response: VerifyBatchPaymentResponse | undefined,
+): number | undefined {
+    if (response?.totalAmount !== undefined) return response.totalAmount
+    const kobo = response?.paystackResponse?.amount
+    if (kobo === undefined) return undefined
+    return kobo / 100
+}
+
+// ── Voucher Receipt ─────────────────────────────────────────────────
+// Returned by `GET /voucher/:voucherReference`. The agent pastes the
+// `voucherReference` they got from the verify-batch response (or a
+// receipt email) to look up the list of students the voucher covers.
+// Only students with `isPaid: true` are eligible for download — even
+// though the voucher is the receipt, the per-student payment flag is
+// the actual download gate.
+export interface VoucherStudent {
+    _id: string
+    examNumber?: string
+    studentName: string
+    isPaid: boolean
+}
+
+export interface VoucherSchool {
+    _id: string
+    schoolName: string
+    lga: string
+    schoolCode?: string
+    hasAccount?: boolean
+    isVerified?: boolean
+}
+
+export interface VoucherResponse {
+    _id: string
+    voucherReference: string
+    paymentReference: string
+    examType: 'BECE' | 'UBEAT' | string
+    examYear: number
+    school: VoucherSchool
+    schoolName: string
+    lga: string
+    studentCount: number
+    /** Total paid in NAIRA (NOT kobo). */
+    amountPaid: number
+    studentIds: VoucherStudent[]
+    /** Backend Mongoose model name — usually "Bece" or "Ubeat". */
+    studentModel: string
+    createdAt: string
+    updatedAt: string
+}
+
+export interface VoucherDownloadStudent {
+    studentName: string
+    examYear: number
+    examNo: string
+    grade: string
+}
+
+export interface VoucherDownloadResponse {
+    schoolName: string
+    students: VoucherDownloadStudent[]
+}
+
+/**
+ * Reduce a voucher's `studentIds` to the IDs the agent is actually
+ * allowed to download. Filters out anything the backend hasn't yet
+ * marked paid (the per-student payment flag is the download gate;
+ * the voucher is just the receipt).
+ */
+export function getVoucherDownloadableIds(
+    voucher: VoucherResponse | undefined | null,
+): string[] {
+    if (!voucher?.studentIds) return []
+    return voucher.studentIds
+        .filter(s => s.isPaid && !!s._id)
+        .map(s => s._id)
 }
 
 // Match returned by find-my-result / find-exam-number endpoints
@@ -257,6 +577,134 @@ export const studentApi = apiSlice.injectEndpoints({
             }),
         }),
 
+        // Bulk Downloads (agent) — list every student in a school cohort
+        // for the year/LGA/school selected in the search form.
+        // Backend contract: POST /{ubeat|bece}/students/by-school
+        //   body      : { year, lga, schoolId, page, limit }
+        //   query     : ?paymentStatus=paid|unpaid
+        //   response  : { data: BulkStudentListItem[], pagination: { total, page, limit, totalPages, ... } }
+        getBulkStudentsBySchool: builder.query<BulkStudentsResponse, BulkStudentsBySchoolRequest & { examType: ExamTypeEnum }>({
+            query: ({ examType, year, lga, schoolId, page, limit, paymentStatus }) => {
+                const url = new URL(`${API_BASE_URL}${endpoints.GET_BULK_STUDENTS_BY_SCHOOL(examType)}`)
+                if (paymentStatus) url.searchParams.set('paymentStatus', paymentStatus)
+                return {
+                    url: url.toString(),
+                    method: 'POST',
+                    body: {
+                        year,
+                        lga,
+                        schoolId,
+                        page,
+                        limit,
+                    },
+                }
+            },
+            transformResponse: async (response: unknown) => {
+                // Normalize the backend payload to `BulkStudentsResponse`.
+                // Accepted shapes:
+                //   1. Canonical: { data: [...], pagination: { total, page, limit, totalPages, ... } }
+                //   2. Flat-paginated: { data, total, page, limit, totalPages }  (older deployments)
+                //   3. Legacy array: [ ... ]                                       (single page, all rows)
+                //   4. Funnel-encrypted: { data: '<cipher>' }                   (decrypt then re-normalize)
+                const raw = response as { data?: unknown }
+
+                const emptyPagination: BulkStudentsPagination = {
+                    total: 0, page: 1, limit: 0, totalPages: 0,
+                    hasNextPage: false, hasPreviousPage: false,
+                }
+
+                const normalize = (payload: unknown): BulkStudentsResponse => {
+                    if (Array.isArray(payload)) {
+                        return {
+                            data: payload as BulkStudentListItem[],
+                            pagination: {
+                                total: payload.length,
+                                page: 1,
+                                limit: payload.length,
+                                totalPages: 1,
+                                hasNextPage: false,
+                                hasPreviousPage: false,
+                            },
+                        }
+                    }
+                    if (payload && typeof payload === 'object') {
+                        const obj = payload as {
+                            data?: unknown
+                            pagination?: Partial<BulkStudentsPagination>
+                            // flat-paginated fallbacks:
+                            total?: number
+                            page?: number
+                            limit?: number
+                            totalPages?: number
+                            currentPage?: number
+                            totalItems?: number
+                        }
+                        if (Array.isArray(obj.data)) {
+                            const data = obj.data
+                            // Prefer nested `pagination`, fall back to flat fields.
+                            if (obj.pagination && typeof obj.pagination === 'object') {
+                                const p = obj.pagination
+                                const total = p.total ?? data.length
+                                const page = p.page ?? 1
+                                const limit = p.limit ?? data.length
+                                const totalPages = p.totalPages ?? Math.max(1, Math.ceil(total / limit))
+                                return {
+                                    data,
+                                    pagination: {
+                                        total,
+                                        page,
+                                        limit,
+                                        totalPages,
+                                        hasNextPage: p.hasNextPage ?? page < totalPages,
+                                        hasPreviousPage: p.hasPreviousPage ?? page > 1,
+                                    },
+                                }
+                            }
+                            // Flat-paginated fallback.
+                            const total = obj.totalItems ?? obj.total ?? data.length
+                            const page = obj.currentPage ?? obj.page ?? 1
+                            const limit = obj.limit ?? data.length
+                            const totalPages = obj.totalPages ?? Math.max(1, Math.ceil(total / limit))
+                            return {
+                                data,
+                                pagination: {
+                                    total, page, limit, totalPages,
+                                    hasNextPage: page < totalPages,
+                                    hasPreviousPage: page > 1,
+                                },
+                            }
+                        }
+                    }
+                    return { data: [], pagination: emptyPagination }
+                }
+
+                if (typeof raw?.data === 'string') {
+                    if (!(await isApiResponseDecryptConfigured())) {
+                        return normalize(response)
+                    }
+                    try {
+                        const decrypted = await decryptApiResponseFrom<unknown>(raw as { data: string }, 'data')
+                        return normalize(decrypted)
+                    } catch (e) {
+                        console.warn('apiResponseFunnel: decrypt failed for bulk students, using raw response.', e)
+                        return normalize(response)
+                    }
+                }
+                // The canonical response is `{ data: [...], pagination: {...} }`.
+                // We must pass the *full* response to `normalize` so the
+                // sibling `pagination` object isn't discarded. Only unwrap
+                // `raw.data` when there's no `pagination` sibling (i.e. the
+                // legacy/unwrapped shape where `data` is the array itself).
+                const payload = (raw && typeof raw === 'object' && 'pagination' in raw)
+                    ? raw
+                    : (raw?.data ?? response)
+                return normalize(payload)
+            },
+            providesTags: (result, error, { examType, schoolId, year, page, limit, paymentStatus }) => [
+                { type: 'Students', id: `BULK-${examType}-${schoolId}-${year}-p${page ?? 1}-l${limit ?? 25}-${paymentStatus ?? 'all'}` },
+            ],
+        }),
+
         // Get BECE student result by exam number or _id
         getBECEResult: builder.query<BECEStudentResult, { _id?: string; examNo?: string; year?: string }>({
             query: ({ _id, examNo, year }) => ({
@@ -325,6 +773,42 @@ export const studentApi = apiSlice.injectEndpoints({
                 return response as MultiMatchResult[]
             },
         }),
+
+        // ── Bulk Payments (agent) ───────────────────────────────────────
+        // Initiate a single Paystack transaction that covers every student
+        // the agent has selected. The backend persists the `studentIds` in
+        // the transaction metadata; on `verify`, it marks each saved
+        // student as paid. The single-student flow is unaffected.
+        createBatchPayment: builder.mutation<CreateBatchPaymentResponse, CreateBatchPaymentRequest & { callbackUrl: string }>({
+            query: ({ callbackUrl, ...body }) => ({
+                url: `${API_BASE_URL}${endpoints.CREATE_BATCH_PAYMENT}?callbackUrl=${encodeURIComponent(callbackUrl)}`,
+                method: 'POST',
+                body,
+            }),
+        }),
+
+        // Verify a batch payment by its Paystack reference. The bulk-
+        // downloads page fires this automatically when it detects
+        // `?reference=...` in the URL (i.e. Paystack redirected back from
+        // checkout). A successful response invalidates the bulk-students
+        // cache so the table re-fetches and shows the newly-paid rows.
+        verifyBatchPayment: builder.query<VerifyBatchPaymentResponse, string>({
+            query: (reference) => `${API_BASE_URL}${endpoints.VERIFY_BATCH_PAYMENT(reference)}`,
+        }),
+
+        // Voucher lookup — fetch the full voucher record by its reference
+        // (e.g. `VCH-1780658070803-33401`). Used by the bulk-downloads page
+        // to gate downloads on a valid receipt: the voucher's `studentIds`
+        // is the list of students the agent paid for, and the agent can
+        // only download certs for those flagged `isPaid: true`.
+        getVoucher: builder.query<VoucherResponse, string>({
+            query: (voucherReference) => `${API_BASE_URL}${endpoints.GET_VOUCHER(voucherReference)}`,
+            providesTags: (_r, _e, ref) => [{ type: 'Voucher', id: ref }],
+        }),
+        getVoucherDownload: builder.query<VoucherDownloadResponse, string>({
+            query: (voucherReference) =>
+                `${API_BASE_URL}${endpoints.GET_VOUCHER_DOWNLOAD(voucherReference)}`,
+        }),
     }),
     overrideExisting: true,
 })
@@ -334,8 +818,10 @@ export const {
     useGetUBEATResultQuery,
     useGetBECEResultQuery,
     useGetAvailableYearsQuery,
+    useGetBulkStudentsBySchoolQuery,
     useLazyGetUBEATResultQuery,
     useLazyGetBECEResultQuery,
+    useLazyGetBulkStudentsBySchoolQuery,
     useFindUBEATResultMutation,
     useFindBECEResultMutation,
     useCreateBECEPaymentMutation,
@@ -345,4 +831,10 @@ export const {
     useSetUbeatPaymentEmailMutation,
     useFindMultipleMatchesMutation,
     useFindBECEMultipleMatchesMutation,
+    useCreateBatchPaymentMutation,
+    useVerifyBatchPaymentQuery,
+    useLazyVerifyBatchPaymentQuery,
+    useGetVoucherQuery,
+    useLazyGetVoucherQuery,
+    useLazyGetVoucherDownloadQuery,
 } = studentApi

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkActionBar.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkActionBar.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import React from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { IoCardOutline, IoClose, IoSparkles } from 'react-icons/io5'
+import { formatNaira, type BulkExamConfig } from './examConfig'
+import type { BulkSelectionSummary } from './types'
+
+interface BulkActionBarProps {
+    config: BulkExamConfig
+    summary: BulkSelectionSummary
+    onPay: () => void
+    onClearSelection: () => void
+    /** True while a bulk payment or download mutation is in flight. */
+    isProcessing?: boolean
+    /** Optional label shown while processing. */
+    processingLabel?: string
+}
+
+/**
+ * Sticky bottom action bar that appears whenever the agent has at least
+ * one selection. Lives in a fixed container so it never overlaps content
+ * when the table is short.
+ */
+export default function BulkActionBar({
+    config,
+    summary,
+    onPay,
+    onClearSelection,
+    isProcessing = false,
+    processingLabel = 'Processing…',
+}: BulkActionBarProps) {
+    const { selectedCount, payableCount, downloadableCount, totalAmount } = summary
+    const visible = selectedCount > 0
+
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    initial={{ y: 80, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    exit={{ y: 80, opacity: 0 }}
+                    transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+                    role="region"
+                    aria-label="Bulk actions"
+                    className="fixed bottom-3 left-1/2 -translate-x-1/2 z-40 w-[calc(100vw-1.5rem)] max-w-5xl"
+                >
+                    <div className="bg-white border border-gray-200 rounded-2xl shadow-[0_12px_40px_rgba(0,0,0,0.12)] px-3 sm:px-5 py-3">
+                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+
+                            {/* Selection summary */}
+                            <div className="flex items-center gap-3 min-w-0">
+                                <button
+                                    type="button"
+                                    onClick={onClearSelection}
+                                    disabled={isProcessing}
+                                    title="Clear selection"
+                                    className="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    <IoClose className="w-4 h-4" />
+                                </button>
+
+                                <div className="flex items-center gap-2 min-w-0">
+                                    <div className="hidden sm:flex w-9 h-9 rounded-xl bg-green-50 text-green-600 items-center justify-center flex-shrink-0">
+                                        <IoSparkles className="w-4 h-4" />
+                                    </div>
+                                    <div className="min-w-0">
+                                        <p className="text-sm font-semibold text-gray-900 truncate">
+                                            {selectedCount} student{selectedCount === 1 ? '' : 's'} selected
+                                        </p>
+                                        <p className="text-[11px] text-gray-500 truncate">
+                                            {payableCount} unpaid · {downloadableCount} ready to download
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Total amount */}
+                            <div className="hidden md:flex items-center gap-2 flex-shrink-0 px-3 py-1.5 rounded-lg bg-gray-50 border border-gray-200">
+                                <span className="text-[11px] uppercase tracking-wide text-gray-500">Total due</span>
+                                <span className="text-sm font-bold text-gray-900 tabular-nums">
+                                    {formatNaira(totalAmount)}
+                                </span>
+                            </div>
+
+                            {/* Actions */}
+                            <div className="flex items-center gap-2 flex-shrink-0">
+                                <button
+                                    type="button"
+                                    onClick={onPay}
+                                    disabled={isProcessing || payableCount < 20}
+                                    className={[
+                                        'flex-1 md:flex-none inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold transition-all',
+                                        'text-white bg-green-600 hover:bg-green-700 cursor-pointer',
+                                        'disabled:opacity-50 disabled:cursor-not-allowed',
+                                        !isProcessing && payableCount >= 20
+                                            ? 'shadow-[0_4px_rgba(0,0,0,0.12)] active:shadow-[0_0px_rgba(0,0,0,1)] active:translate-y-1'
+                                            : '',
+                                    ].join(' ')}
+                                >
+                                    {isProcessing ? (
+                                        <>
+                                            <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                            <span className="hidden sm:inline">{processingLabel}</span>
+                                        </>
+                                    ) : payableCount > 0 && payableCount < 20 ? (
+                                        <>
+                                            <IoCardOutline className="w-4 h-4" />
+                                            <span>Select {20 - payableCount} more</span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <IoCardOutline className="w-4 h-4" />
+                                            <span className="hidden sm:inline">
+                                                Pay for {payableCount || ''} · {formatNaira(totalAmount)}
+                                            </span>
+                                            <span className="sm:hidden">Pay {formatNaira(totalAmount)}</span>
+                                        </>
+                                    )}
+                                </button>
+
+
+                            </div>
+                        </div>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkDownloadModal.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkDownloadModal.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import React from 'react'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { IoArchiveOutline, IoCheckmarkCircle, IoCloseCircle } from 'react-icons/io5'
+import type { BulkExamConfig } from './examConfig'
+
+export type BulkDownloadStage =
+    | 'idle'
+    | 'preparing'   // server is assembling the ZIP
+    | 'downloading' // browser is streaming the file
+    | 'done'
+    | 'error'
+
+interface BulkDownloadModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    config: BulkExamConfig
+    stage: BulkDownloadStage
+    /** 0-100, only meaningful when stage === 'preparing' | 'downloading'. */
+    progress?: number
+    /** Number of certificates expected in the ZIP. */
+    certificateCount: number
+    /** Optional error message — shown when stage === 'error'. */
+    errorMessage?: string
+    /** Retry handler for the error state. */
+    onRetry?: () => void
+}
+
+/**
+ * Progress modal for the bulk ZIP download.
+ *
+ * The progress bar uses a striped animation while preparing (no real %),
+ * then snaps to actual progress once the browser starts streaming.
+ */
+export default function BulkDownloadModal({
+    open,
+    onOpenChange,
+    config,
+    stage,
+    progress = 0,
+    certificateCount,
+    errorMessage,
+    onRetry,
+}: BulkDownloadModalProps) {
+    const isBusy = stage === 'preparing' || stage === 'downloading'
+    const showProgress = stage === 'downloading'
+
+    return (
+        <Dialog open={open} onOpenChange={isBusy ? undefined : onOpenChange}>
+            <DialogContent className="sm:max-w-md rounded-2xl p-0 overflow-hidden gap-0">
+                <div
+                    className={[
+                        'h-1.5 w-full',
+                        stage === 'error'
+                            ? 'bg-gradient-to-r from-red-500 to-red-600'
+                            : 'bg-gradient-to-r from-blue-500 to-blue-600',
+                    ].join(' ')}
+                />
+
+                <div className="p-6">
+                    <DialogHeader className="mb-4">
+                        <div
+                            className={[
+                                'flex items-center justify-center w-12 h-12 rounded-full mb-4 mx-auto border',
+                                stage === 'error'
+                                    ? 'bg-red-50 border-red-100'
+                                    : stage === 'done'
+                                        ? 'bg-green-50 border-green-100'
+                                        : 'bg-blue-50 border-blue-100',
+                            ].join(' ')}
+                        >
+                            {stage === 'error' ? (
+                                <IoCloseCircle className="w-6 h-6 text-red-600" />
+                            ) : stage === 'done' ? (
+                                <IoCheckmarkCircle className="w-6 h-6 text-green-600" />
+                            ) : (
+                                <IoArchiveOutline className="w-6 h-6 text-blue-600" />
+                            )}
+                        </div>
+
+                        <DialogTitle className="text-center text-lg font-semibold text-gray-900">
+                            {stage === 'error'
+                                ? 'Download failed'
+                                : stage === 'done'
+                                    ? 'Download complete'
+                                    : stage === 'preparing'
+                                        ? 'Preparing your ZIP…'
+                                        : `Downloading ${certificateCount} ${config.certificateLabel}s`}
+                        </DialogTitle>
+
+                        <DialogDescription className="text-sm text-gray-500 text-center mt-1 leading-relaxed">
+                            {stage === 'error'
+                                ? errorMessage ?? 'Something went wrong while building your ZIP file.'
+                                : stage === 'done'
+                                    ? `Your ZIP file has been saved. Look for ${config.zipFilenamePrefix}_<date>.zip in your downloads folder.`
+                                    : stage === 'preparing'
+                                        ? `We\u2019re packaging ${certificateCount} certificate${certificateCount === 1 ? '' : 's'}. This takes a few seconds.`
+                                        : 'Don\u2019t close this tab — the file is streaming to your device.'}
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {/* Progress bar */}
+                    {(stage === 'preparing' || stage === 'downloading') && (
+                        <div className="mb-4">
+                            <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
+                                {showProgress ? (
+                                    <div
+                                        className="h-full bg-blue-500 transition-[width] duration-300"
+                                        style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+                                    />
+                                ) : (
+                                    <div className="h-full w-1/3 bg-blue-500 animate-[pulse_1.4s_ease-in-out_infinite] rounded-full" />
+                                )}
+                            </div>
+                            {showProgress && (
+                                <p className="text-[11px] text-gray-500 mt-1.5 text-right tabular-nums">
+                                    {Math.round(progress)}%
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    <DialogFooter className="sm:justify-end gap-2">
+                        {stage === 'error' && onRetry && (
+                            <button
+                                type="button"
+                                onClick={onRetry}
+                                className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors cursor-pointer"
+                            >
+                                Try again
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => onOpenChange(false)}
+                            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {stage === 'done' ? 'Close' : isBusy ? 'Please wait…' : 'Cancel'}
+                        </button>
+                    </DialogFooter>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkDownloadsLanding.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkDownloadsLanding.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import React from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import {
+    IoArrowBack,
+    IoArchiveOutline,
+    IoArrowForward,
+    IoCheckmarkCircle,
+    IoLayersOutline,
+    IoReceiptOutline,
+} from 'react-icons/io5'
+import { motion } from 'framer-motion'
+
+import { BULK_EXAM_CONFIGS, formatNaira, type BulkExamConfig } from './examConfig'
+
+interface ExamCardData {
+    config: BulkExamConfig
+    icon: React.ReactNode
+    accent: string
+    iconBg: string
+}
+
+const EXAM_CARDS: ExamCardData[] = [
+    {
+        config: BULK_EXAM_CONFIGS.bece,
+        icon: <IoLayersOutline className="w-6 h-6" />,
+        accent: 'from-emerald-50 to-green-50',
+        iconBg: 'bg-emerald-100 text-emerald-700',
+    },
+    {
+        config: BULK_EXAM_CONFIGS.ubeat,
+        icon: <IoArchiveOutline className="w-6 h-6" />,
+        accent: 'from-sky-50 to-blue-50',
+        iconBg: 'bg-sky-100 text-sky-700',
+    },
+]
+
+const BULK_FEATURES = [
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'Pay once for the whole cohort',
+    },
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'One ZIP file, all certificates',
+    },
+    {
+        icon: <IoCheckmarkCircle className="w-4 h-4 text-emerald-600" />,
+        label: 'Receipt emailed automatically',
+    },
+]
+
+const cardVariants = {
+    hidden: { opacity: 0, y: 14 },
+    visible: { opacity: 1, y: 0, transition: { type: 'spring' as const, stiffness: 260, damping: 26 } },
+}
+
+/**
+ * Exam-picker landing for the bulk-downloads agent flow.
+ *
+ * NOTE: Currently dead code — not imported by any `page.tsx`. The two
+ * `/result-checking/{bece,ubeat}/bulk-downloads/page.tsx` files render
+ * `BulkPageContent` directly, bypassing this picker. The intended route
+ * was `/result-checking/bulk-downloads` (a shared exam-picker screen) but
+ * that page was never created; the bulk-downloads flow is reached via
+ * the per-exam links from the main `/result-checking/{bece,ubeat}`
+ * landing pages instead. Wire this up by creating
+ * `src/app/result-checking/bulk-downloads/page.tsx` that renders
+ * `<BulkDownloadsLanding />` if the picker is ever wanted.
+ */
+export default function BulkDownloadsLanding() {
+    const router = useRouter()
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-green-50/40 via-white to-blue-50/30 flex flex-col">
+            {/* Top bar */}
+            <header className="bg-white border-b border-gray-100 sticky top-0 z-20">
+                <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between gap-3">
+                    <Link
+                        href="/result-checking"
+                        className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                    >
+                        <IoArrowBack className="w-4 h-4" />
+                        <span className="hidden sm:inline">Back to Student Portal</span>
+                        <span className="sm:hidden">Back</span>
+                    </Link>
+                    <div className="flex items-center gap-2">
+                        <Image
+                            src="/images/ministry-logo.png"
+                            alt="MOPSE"
+                            width={32}
+                            height={32}
+                            className="h-8 w-auto object-contain"
+                        />
+                        <div className="border-l border-gray-200 pl-2">
+                            <span className="text-sm font-semibold text-gray-900 block leading-tight">
+                                Bulk Downloads
+                            </span>
+                            <span className="text-[10px] text-gray-500 block leading-tight">
+                                Agent Portal
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            <main className="flex-1 max-w-6xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+                {/* Hero */}
+                <section className="mb-10">
+                    <div className="inline-flex items-center gap-2 bg-emerald-50 border border-emerald-100 text-emerald-700 text-xs font-semibold rounded-full px-3 py-1 mb-4">
+                        <IoReceiptOutline className="w-3.5 h-3.5" />
+                        <span>Agent-only · Whole-cohort processing</span>
+                    </div>
+                    <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-900 mb-3 leading-tight">
+                        Bulk Result Downloads
+                    </h1>
+                    <p className="text-base sm:text-lg text-gray-600 max-w-2xl leading-relaxed">
+                        Search a full school cohort, pay for every unpaid result in a single transaction,
+                        and download every certificate as one ZIP file. Pick the exam type to begin.
+                    </p>
+                </section>
+
+                {/* Exam picker */}
+                <section className="mb-10">
+                    <h2 className="text-lg font-bold text-gray-900 mb-4">Choose an examination</h2>
+                    <motion.div
+                        className="grid grid-cols-1 md:grid-cols-2 gap-5"
+                        initial="hidden"
+                        animate="visible"
+                        transition={{ staggerChildren: 0.08 }}
+                    >
+                        {EXAM_CARDS.map(({ config, icon, accent, iconBg }) => (
+                            <motion.button
+                                key={config.examType}
+                                variants={cardVariants}
+                                whileHover={{ y: -4 }}
+                                whileTap={{ scale: 0.99 }}
+                                onClick={() => router.push(config.bulkRoute)}
+                                className={[
+                                    'group text-left p-6 rounded-2xl bg-gradient-to-br',
+                                    accent,
+                                    'border border-white/80 shadow-sm hover:shadow-lg',
+                                    'transition-all duration-200 cursor-pointer',
+                                ].join(' ')}
+                            >
+                                <div className="flex items-start gap-4 mb-4">
+                                    <div
+                                        className={[
+                                            'flex items-center justify-center w-12 h-12 rounded-2xl flex-shrink-0',
+                                            iconBg,
+                                        ].join(' ')}
+                                    >
+                                        {icon}
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <h3 className="text-xl font-bold text-gray-900 mb-0.5">
+                                            {config.shortName}
+                                        </h3>
+                                        <p className="text-xs text-gray-600 font-medium">
+                                            {config.fullName}
+                                        </p>
+                                    </div>
+                                    <IoArrowForward className="w-5 h-5 text-gray-400 group-hover:text-gray-700 group-hover:translate-x-1 transition-all" />
+                                </div>
+
+                                <p className="text-sm text-gray-700 leading-relaxed mb-4">
+                                    Bulk-download {config.certificateLabel}s for an entire school cohort.
+                                    {' '}{formatNaira(config.pricePerStudent)} per certificate.
+                                </p>
+
+                                <ul className="space-y-1.5 mb-5">
+                                    {BULK_FEATURES.map((feature) => (
+                                        <li
+                                            key={feature.label}
+                                            className="flex items-center gap-2 text-xs text-gray-700"
+                                        >
+                                            {feature.icon}
+                                            <span>{feature.label}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+
+                                <div className="inline-flex items-center justify-center w-full py-2.5 rounded-lg text-sm font-semibold bg-white text-gray-900 border border-gray-200 group-hover:bg-gray-50 transition-colors">
+                                    Start {config.shortName} bulk download
+                                </div>
+                            </motion.button>
+                        ))}
+                    </motion.div>
+                </section>
+
+                {/* Helper banner */}
+                <section className="mb-10">
+                    <div className="bg-amber-50 border border-amber-100 rounded-2xl p-5 flex items-start gap-3">
+                        <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-white border border-amber-100 flex items-center justify-center">
+                            <span className="text-lg">💡</span>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <h3 className="text-sm font-semibold text-amber-900 mb-1">
+                                How bulk downloads work
+                            </h3>
+                            <ol className="text-sm text-amber-900/80 space-y-1 list-decimal list-inside">
+                                <li>Pick the exam, then the year, LGA and school.</li>
+                                <li>Select the students whose certificates you need.</li>
+                                <li>
+                                    Pay {formatNaira(BULK_EXAM_CONFIGS.bece.pricePerStudent)} per unpaid student in a single transaction.
+                                </li>
+                                <li>Download every paid certificate as a ZIP file.</li>
+                            </ol>
+                        </div>
+                    </div>
+                </section>
+
+                {/* Single-student fallback */}
+                <section className="text-center">
+                    <p className="text-xs text-gray-500">
+                        Only need one student’s result?{' '}
+                        <Link
+                            href="/result-checking"
+                            className="text-green-600 hover:text-green-700 font-medium"
+                        >
+                            Go to the standard student portal
+                        </Link>
+                    </p>
+                </section>
+            </main>
+
+            <footer className="border-t border-gray-100 py-6 bg-gray-50">
+                <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                    <p className="text-xs text-gray-500">
+                        © {new Date().getFullYear()} Imo State Ministry of Primary and Secondary Education
+                    </p>
+                </div>
+            </footer>
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkPageContent.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkPageContent.tsx
@@ -1,0 +1,1019 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useDispatch } from 'react-redux'
+import { IoCheckmarkCircle, IoChevronDown, IoCopyOutline, IoSearch, IoSwapHorizontal } from 'react-icons/io5'
+import toast from 'react-hot-toast'
+import JSZip from 'jszip'
+
+import PortalHeader from '@/app/result-checking/components/Portalheader'
+import BulkSearchForm from './BulkSearchForm'
+import SearchFilterSummary from './SearchFilterSummary'
+import StudentResultsTable from './StudentResultsTable'
+import BulkActionBar from './BulkActionBar'
+import BulkPaymentModal from './BulkPaymentModal'
+import BulkDownloadModal, { type BulkDownloadStage } from './BulkDownloadModal'
+import VoucherLookup from './VoucherLookup'
+import {
+    useCreateBatchPaymentMutation,
+    useGetBulkStudentsBySchoolQuery,
+    useLazyGetVoucherDownloadQuery,
+    useVerifyBatchPaymentQuery,
+    getVerifiedStudentCount,
+    studentApi,
+    type VoucherResponse,
+} from '@/app/result-checking/store/api/studentApi'
+import { ExamTypeEnum } from '@/app/portal/store/api/authApi'
+import { mapBulkStudentListItem } from './bulkApiAdapter'
+import { type BulkExamConfig } from './examConfig'
+import {
+    saveVoucherToStorage,
+    loadVoucherFromStorage,
+    hasVoucherInStorage,
+    clearVoucherFromStorage,
+} from './voucherStorage'
+import type {
+    BulkSearchFilters,
+    BulkSelectionSummary,
+    BulkStatusFilter,
+    BulkStudent,
+} from './types'
+import { generateUBEATCertificate } from '@/app/exam-portal/dashboard/schools/[schoolId]/ubeat/utils/certificateGenerator'
+import type { UBEATStudent } from '@/app/exam-portal/dashboard/schools/types/student.types'
+
+interface BulkPageContentProps {
+    config: BulkExamConfig
+}
+
+const DEFAULT_FILTERS: BulkSearchFilters = {
+    examYear: '',
+    lga: '',
+    school: { id: '', name: '' },
+}
+
+const ITEMS_PER_PAGE_DEFAULT = 12
+
+/** Normalize a string for case- and whitespace-insensitive matching. */
+function normalizeForSearch(value: string): string {
+    return value.trim().toLowerCase()
+}
+
+/**
+ * Top-level client component for `/bulk-downloads/{bece,ubeat}`.
+ *
+ * Owns all UI state:
+ *   - search form values & "form vs. results" mode
+ *   - in-table search query + status filter (All / Unpaid / Paid)
+ *   - client-side paginated cohort, items-per-page
+ *   - per-row selection set (with cross-page select-all matching)
+ *   - payment + download modal states
+ *
+ * Data flow:
+ *   1. User picks year + LGA + school in `BulkSearchForm`
+ *   2. We POST to `/{examType}/students/by-school` via RTK Query
+ *   3. The minimal `BulkStudentListItem` response is mapped to `BulkStudent`
+ *      (see `bulkApiAdapter.ts`)
+ *   4. The cohort is sliced by status filter → search → page
+ */
+export default function BulkPageContent({ config }: BulkPageContentProps) {
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const dispatch = useDispatch()
+
+    // ── Search state ─────────────────────────────────────────────────────
+    const [filters, setFilters] = useState<BulkSearchFilters>(DEFAULT_FILTERS)
+    const [appliedFilters, setAppliedFilters] = useState<BulkSearchFilters | null>(null)
+
+    // ── Toolbar (in-table) state ─────────────────────────────────────────
+    const [searchQuery, setSearchQuery] = useState('')
+    const [statusFilter, setStatusFilter] = useState<BulkStatusFilter>('all')
+
+    // ── Pagination ───────────────────────────────────────────────────────
+    const [currentPage, setCurrentPage] = useState(1)
+    const [itemsPerPage, setItemsPerPage] = useState(ITEMS_PER_PAGE_DEFAULT)
+
+    // ── Selection ────────────────────────────────────────────────────────
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+    // ── Modal / download state ───────────────────────────────────────────
+    const [isPaying, setIsPaying] = useState(false)
+    const [paymentOpen, setPaymentOpen] = useState(false)
+    const [downloadStage, setDownloadStage] = useState<BulkDownloadStage>('idle')
+    const [downloadProgress, setDownloadProgress] = useState(0)
+    const [downloadOpen, setDownloadOpen] = useState(false)
+    /**
+     * Number of certificates the modal is currently simulating a download
+     * for. Driven by whichever entry point opened the modal (selection-
+     * based or voucher-based). Read by the modal's `certificateCount` prop
+     * and its `onRetry` button.
+     */
+    const [downloadCertificateCount, setDownloadCertificateCount] = useState(0)
+    const [downloadVoucherRef, setDownloadVoucherRef] = useState('')
+    /**
+     * Voucher reference from the URL — kept for direct `?voucher=…` links
+     * (e.g. bookmarks). After a successful verify, we store the full
+     * voucher in localStorage instead and skip the URL param.
+     */
+    const urlVoucher = searchParams.get('voucher') ?? ''
+
+    // ── Saved voucher from localStorage ─────────────────────────────────
+    const [savedVoucher, setSavedVoucher] = useState<VoucherResponse | null>(null)
+    const [verifiedAt, setVerifiedAt] = useState<string | null>(null)
+
+    // Voucher reference shown in the post-verify copy modal.
+    const [voucherRefModal, setVoucherRefModal] = useState<string | null>(null)
+
+    // On mount, try to load a previously-saved voucher from localStorage.
+    // This runs once per mount — only when there's no `?reference=` callback
+    // and no `?voucher=` in the URL (those take priority).
+    useEffect(() => {
+        const ref = searchParams.get('reference') ?? searchParams.get('trxref')
+        const vch = searchParams.get('voucher')
+        if (ref || vch) return // active callback or direct link — don't load saved
+
+        if (!hasVoucherInStorage(config.examType)) return
+
+        loadVoucherFromStorage(config.examType).then(v => {
+            if (v) setSavedVoucher(v)
+        })
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+    /**
+     * Whether the (secondary) cohort search section is expanded. Default
+     * collapsed — the voucher view at the top is the primary entry point
+     * and the LGA × School search is only needed when the agent hasn't
+     * paid yet. Auto-expands the first time the user submits a search so
+     * they can see their cohort without an extra click.
+     */
+    const [cohortExpanded, setCohortExpanded] = useState(false)
+    const [voucherActive, setVoucherActive] = useState(false)
+
+    const handleClearSavedVoucher = useCallback(() => {
+        clearVoucherFromStorage(config.examType)
+        setSavedVoucher(null)
+        setVerifiedAt(null)
+        setVoucherActive(false)
+    }, [config.examType])
+
+    const handleDismissVoucherModal = useCallback(async () => {
+        if (voucherRefModal) {
+            try {
+                await navigator.clipboard.writeText(voucherRefModal)
+                toast.success('Voucher reference copied!')
+            } catch {
+                // clipboard not available — user can still copy manually
+            }
+        }
+        setVoucherRefModal(null)
+        router.replace(config.bulkRoute)
+    }, [voucherRefModal, router, config.bulkRoute])
+
+    /** Persist a freshly-fetched voucher to localStorage as a "session". */
+    const handleVoucherLoaded = useCallback(
+        async (voucher: VoucherResponse) => {
+            await saveVoucherToStorage(config.examType, voucher)
+            setSavedVoucher(voucher)
+        },
+        [config.examType],
+    )
+
+    useEffect(() => {
+        if (appliedFilters) setCohortExpanded(true)
+    }, [appliedFilters])
+
+    // ── Live cohort query ────────────────────────────────────────────────
+    // Server-side pagination + status filter. The response is a single page
+    // (currentPage) of the (status-filtered) cohort. Free-text search is
+    // still applied client-side on the current page (see `matchingCohort`).
+    const yearNum = appliedFilters ? Number(appliedFilters.examYear) : NaN
+    const queryArgs = appliedFilters && Number.isFinite(yearNum) && appliedFilters.school.id
+        ? {
+            examType: config.examType === 'bece'
+                ? ExamTypeEnum.BECE
+                : ExamTypeEnum.UBEAT,
+            year: yearNum,
+            lga: appliedFilters.lga,
+            schoolId: appliedFilters.school.id,
+            page: currentPage,
+            limit: itemsPerPage,
+            paymentStatus: statusFilter === 'all' ? undefined : statusFilter,
+        }
+        : undefined
+
+    const {
+        data: apiResponse,
+        isLoading: isLoadingCohort,
+        isFetching: isFetchingCohort,
+        error: cohortError,
+    } = useGetBulkStudentsBySchoolQuery(queryArgs!, {
+        skip: !queryArgs,
+    })
+
+    // Map the current page's items to the wider BulkStudent shape.
+    const currentPageStudents: BulkStudent[] = useMemo(() => {
+        if (!apiResponse || !appliedFilters) return []
+        return apiResponse.data.map(item =>
+            mapBulkStudentListItem(item, {
+                schoolId: appliedFilters.school.id,
+                schoolName: appliedFilters.school.name,
+                lga: appliedFilters.lga,
+                examYear: appliedFilters.examYear,
+            }),
+        )
+    }, [apiResponse, appliedFilters])
+
+    // Client-side search filter — narrows the *current page* to the rows
+    // whose name matches. The toolbar's "matchingCount" reflects this
+    // per-page number, so "Select all N" selects every matching row on
+    // the visible page. The user flips pages to accumulate selections.
+    const matchingCohort: BulkStudent[] = useMemo(() => {
+        const needle = normalizeForSearch(searchQuery)
+        if (!needle) return currentPageStudents
+        return currentPageStudents.filter(s =>
+            normalizeForSearch(s.studentName).includes(needle),
+        )
+    }, [currentPageStudents, searchQuery])
+
+    const students: BulkStudent[] = matchingCohort
+
+    // Server-reported totals for the currently status-filtered cohort.
+    const serverTotalItems = apiResponse?.pagination?.total ?? 0
+    const serverTotalPages = apiResponse?.pagination?.totalPages ?? 1
+
+    // Surface API errors as toasts.
+    useEffect(() => {
+        if (cohortError) {
+            const message =
+                'status' in cohortError && cohortError.status === 404
+                    ? 'No students found for that school, LGA, and year.'
+                    : 'Could not load the cohort. Please try again.'
+            toast.error(message)
+        }
+    }, [cohortError])
+
+    // Clamp the current page *only* when it's out of bounds (e.g. the user
+    // changed items-per-page or applied a filter that shrunk the cohort).
+    // We deliberately do NOT reset the page just because the server's last
+    // response was for a different page — that would race with the user's
+    // own navigation clicks and effectively freeze the pagination on page 1.
+    useEffect(() => {
+        if (
+            apiResponse &&
+            serverTotalPages > 0 &&
+            currentPage > serverTotalPages
+        ) {
+            setCurrentPage(serverTotalPages)
+        }
+    }, [apiResponse, serverTotalPages, currentPage])
+
+    // ── Derived selection summary ────────────────────────────────────────
+    const summary: BulkSelectionSummary = useMemo(() => {
+        const selectedOnPage = students.filter(s => selectedIds.has(s._id))
+        const selectedOffPage = selectedIds.size - selectedOnPage.length
+
+        const payableCount =
+            selectedOnPage.filter(s => s.paymentStatus !== 'paid').length + selectedOffPage
+        const downloadableCount = selectedOnPage.filter(
+            s => s.paymentStatus === 'paid' && s.certificateReady,
+        ).length
+
+        return {
+            selectedCount: selectedIds.size,
+            payableCount,
+            downloadableCount,
+            totalAmount: payableCount * config.pricePerStudent,
+        }
+    }, [students, selectedIds, config.pricePerStudent])
+
+    // ── Shift-click selection refs ───────────────────────────────────────
+    // Ref to the current visible student list so the toggle callback can
+    // read indices without re-creating itself on every render.
+    const studentsRef = useRef(students)
+    studentsRef.current = students
+    // Tracks the last individually-clicked row index for shift-click ranges.
+    const lastClickedRef = useRef<number | null>(null)
+    const resetAnchor = useCallback(() => { lastClickedRef.current = null }, [])
+
+    // ── Filter / pagination handlers ─────────────────────────────────────
+    const handleSearchSubmit = useCallback(() => {
+        setAppliedFilters(filters)
+        setCurrentPage(1)
+        setSelectedIds(new Set())
+        setSearchQuery('')
+        setStatusFilter('all')
+        resetAnchor()
+    }, [filters, resetAnchor])
+
+    const handleChangeFilters = useCallback(() => {
+        setAppliedFilters(null)
+        setSelectedIds(new Set())
+        setCurrentPage(1)
+        setSearchQuery('')
+        setStatusFilter('all')
+        setVoucherActive(false)
+        resetAnchor()
+        if (typeof window !== 'undefined') {
+            window.scrollTo({ top: 0, behavior: 'smooth' })
+        }
+    }, [resetAnchor])
+
+    const handlePageChange = useCallback((page: number) => {
+        setCurrentPage(page)
+        resetAnchor()
+        if (typeof window !== 'undefined') {
+            window.scrollTo({ top: 120, behavior: 'smooth' })
+        }
+    }, [resetAnchor])
+
+    const handleItemsPerPageChange = useCallback((n: number) => {
+        setItemsPerPage(n)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    const handleSearchInputChange = useCallback((value: string) => {
+        setSearchQuery(value)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    const handleStatusFilterChange = useCallback((value: BulkStatusFilter) => {
+        setStatusFilter(value)
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    /**
+     * Quick "show all students" — used by the EmptyState's primary CTA
+     * so the user can recover from a dead-end filter without leaving
+     * the results screen or losing their other filter context.
+     */
+    const handleShowAllStatuses = useCallback(() => {
+        setStatusFilter('all')
+        setCurrentPage(1)
+        resetAnchor()
+    }, [resetAnchor])
+
+    // ── Selection handlers ───────────────────────────────────────────────
+    const toggleOne = useCallback((id: string, event?: React.MouseEvent) => {
+        const list = studentsRef.current
+        const currentIdx = list.findIndex(s => s._id === id)
+        if (currentIdx === -1) return
+
+        if (event?.shiftKey && lastClickedRef.current !== null) {
+            const from = Math.min(lastClickedRef.current, currentIdx)
+            const to = Math.max(lastClickedRef.current, currentIdx)
+            setSelectedIds(prev => {
+                const next = new Set(prev)
+                for (let i = from; i <= to; i++) {
+                    const student = list[i]
+                    if (student.paymentStatus !== 'paid') next.add(student._id)
+                }
+                return next
+            })
+        } else {
+            lastClickedRef.current = currentIdx
+            setSelectedIds(prev => {
+                const next = new Set(prev)
+                if (next.has(id)) next.delete(id)
+                else next.add(id)
+                return next
+            })
+        }
+    }, [])
+
+    const clearSelection = useCallback(() => {
+        setSelectedIds(new Set())
+    }, [])
+
+    // ── Voucher download ────────────────────────────────────────────────
+    const [triggerDownload, { isLoading: isDownloading }] = useLazyGetVoucherDownloadQuery()
+
+    // ── Bulk payment ────────────────────────────────────────────────────
+    const [createBatchPayment] = useCreateBatchPaymentMutation()
+
+    const handleStartPayment = useCallback(() => {
+        if (summary.payableCount === 0) {
+            toast('Nothing to pay — your selection is already paid.', { icon: 'ℹ️' })
+            return
+        }
+        if (summary.payableCount < 20) {
+            toast.error(`Select at least 20 unpaid students to proceed (you have ${summary.payableCount}).`)
+            return
+        }
+        if (!appliedFilters) {
+            toast.error('Pick a year, LGA, and school before paying.')
+            return
+        }
+        setPaymentOpen(true)
+    }, [summary.payableCount, appliedFilters])
+
+    const handleConfirmPayment = useCallback(async (_args: { email: string }): Promise<string | undefined> => {
+        // The `email` arg is received for signature parity with the
+        // Paywall's EmailDialog, but the BulkPaymentModal is responsible
+        // for PATCHing it onto the payment after this function returns
+        // (it calls `setBecePaymentEmail` / `setUbeatPaymentEmail` once
+        // the reference is in hand, racing the redirect). We don't use
+        // it here.
+        if (!appliedFilters) return undefined
+
+        // Send the agent's full `selectedIds` as the `studentIds` payload.
+        // The backend dedupes against already-paid students, so it's safe to
+        // include paid rows that are still in the cross-page selection set
+        // (e.g. an agent who ticked a row, refreshed, then re-ticked it).
+        const studentIds = Array.from(selectedIds)
+        if (studentIds.length === 0) {
+            toast.error('No students selected.')
+            return undefined
+        }
+
+        // ── Sticky loading: set true ONCE here. From this point on, the
+        // BulkActionBar shows "Starting payment…" and is disabled. Do NOT
+        // reset isPaying on the success path — the page is about to
+        // navigate and we don't want the action bar to re-enable mid-
+        // navigation. Only the catch block may reset it.
+        setIsPaying(true)
+        try {
+            const callbackUrl =
+                typeof window !== 'undefined'
+                    ? `${window.location.origin}${config.bulkRoute}`
+                    : config.bulkRoute
+
+            const yearNum = Number(appliedFilters.examYear)
+            const response = await createBatchPayment({
+                examType: config.examType === 'bece' ? ExamTypeEnum.BECE : ExamTypeEnum.UBEAT,
+                examYear: yearNum,
+                studentIds,
+                callbackUrl,
+            }).unwrap()
+
+            if (!response.authorizationUrl) {
+                toast.error('Payment gateway did not return a checkout URL. Please try again.')
+                setIsPaying(false)
+                return undefined
+            }
+
+            // Stash the original selection under the reference so the verify
+            // effect (run after Paystack redirects back) can clear the
+            // agent's selection set in the same shape it was in before pay.
+            if (typeof window !== 'undefined') {
+                window.sessionStorage.setItem(
+                    `bulk-payment-selection:${response.reference}`,
+                    JSON.stringify(studentIds),
+                )
+            }
+
+            // ── Sticky loading: redirect is triggered. From this point
+            // forward, do NOT touch isPaying under any code path. The page
+            // is navigating and the action bar should stay disabled.
+            toast.success('Redirecting to Paystack…')
+            window.location.href = response.authorizationUrl
+            return response.reference
+        } catch (err) {
+            console.error('Batch payment initiation failed', err)
+            const apiMessage: string | undefined =
+                err && typeof err === 'object' && 'data' in err
+                    ? (err as { data?: { message?: string } }).data?.message
+                    : undefined
+            toast.error(apiMessage || 'Could not start the payment. Please try again.')
+            // Failure path: reset isPaying so the agent can retry.
+            setIsPaying(false)
+            return undefined
+        }
+    }, [appliedFilters, selectedIds, createBatchPayment, config.bulkRoute, config.examType])
+
+    // ── Bulk ZIP download ───────────────────────────────────────────────
+    // Generates UBEAT certificates client-side via `generateUBEATCertificate`,
+    // zips them with JSZip, and triggers a browser download.
+
+    const processCertificateDownload = useCallback(
+        async (voucherRef: string) => {
+            try {
+                const response = await triggerDownload(voucherRef).unwrap()
+                const eligible = response.students
+
+                if (eligible.length === 0) {
+                    toast.error('No downloadable students found on this voucher.')
+                    setDownloadStage('idle')
+                    setDownloadOpen(false)
+                    return
+                }
+
+                setDownloadStage('downloading')
+                const zip = new JSZip()
+                const total = eligible.length
+                let completed = 0
+                let failed = 0
+
+                const BATCH_SIZE = 3
+                for (let i = 0; i < total; i += BATCH_SIZE) {
+                    const batch = eligible.slice(i, i + BATCH_SIZE)
+                    const results = await Promise.allSettled(
+                        batch.map(async (s) => {
+                            const studentData: UBEATStudent = {
+                                _id: s.examNo,
+                                examNumber: s.examNo,
+                                studentName: s.studentName,
+                                serialNumber: 0,
+                                isPaid: true,
+                                age: 0,
+                                sex: 'male',
+                                lga: '',
+                                school: '',
+                                schoolName: response.schoolName,
+                                examYear: s.examYear,
+                                subjects: {
+                                    mathematics: { ca: 0, exam: 0, total: 0, _id: '' },
+                                    english: { ca: 0, exam: 0, total: 0, _id: '' },
+                                    generalKnowledge: { ca: 0, exam: 0, total: 0, _id: '' },
+                                    igbo: { ca: 0, exam: 0, total: 0, _id: '' },
+                                },
+                                averageScore: 0,
+                                grade: s.grade,
+                                createdAt: '',
+                                updatedAt: '',
+                                __v: 0,
+                            }
+                            const blob = await generateUBEATCertificate(
+                                { student: studentData, schoolName: response.schoolName },
+                                (s.grade?.toLowerCase() as 'pass' | 'credit' | 'distinction') || 'pass',
+                                undefined,
+                                undefined,
+                                true,
+                            )
+                            const filename = `UBEAT_Certificate_${s.examNo.replace(/\//g, '_')}.png`
+                            return { blob: blob as Blob, filename }
+                        }),
+                    )
+
+                    for (const result of results) {
+                        if (result.status === 'fulfilled') {
+                            const r = result.value as { blob: Blob; filename: string }
+                            if (r.blob) zip.file(r.filename, r.blob)
+                            completed++
+                        } else {
+                            failed++
+                            completed++
+                        }
+                    }
+
+                    setDownloadProgress(Math.round((completed / total) * 85))
+                }
+
+                if (completed - failed === 0) {
+                    toast.error('Failed to generate any certificates.')
+                    setDownloadStage('idle')
+                    setDownloadOpen(false)
+                    return
+                }
+
+                setDownloadProgress(90)
+                const zipBlob = await zip.generateAsync({ type: 'blob' })
+                setDownloadProgress(95)
+
+                const url = URL.createObjectURL(zipBlob)
+                const link = document.createElement('a')
+                link.href = url
+                link.download = `${config.zipFilenamePrefix}_${voucherRef}.zip`
+                document.body.appendChild(link)
+                link.click()
+                document.body.removeChild(link)
+                URL.revokeObjectURL(url)
+
+                const successCount = completed - failed
+                if (failed > 0) {
+                    toast(`${successCount} of ${total} certificates downloaded. ${failed} failed.`, { icon: '⚠️' })
+                } else {
+                    toast.success(`${successCount} certificate${successCount === 1 ? '' : 's'} downloaded!`)
+                }
+
+                setDownloadProgress(100)
+                setDownloadStage('done')
+            } catch (err) {
+                console.error('Bulk certificate generation failed:', err)
+                toast.error('Could not generate certificates. Please try again.')
+                setDownloadStage('idle')
+                setDownloadOpen(false)
+            }
+        },
+        [triggerDownload, config.zipFilenamePrefix],
+    )
+
+    const handleVoucherDownloadAll = useCallback(
+        (_paidIds: string[], voucher: VoucherResponse) => {
+            if (_paidIds.length === 0) {
+                toast('No paid students on this voucher.', { icon: 'ℹ️' })
+                return
+            }
+            setDownloadCertificateCount(_paidIds.length)
+            setDownloadVoucherRef(voucher.voucherReference)
+            setDownloadStage('preparing')
+            setDownloadProgress(0)
+            setDownloadOpen(true)
+            processCertificateDownload(voucher.voucherReference)
+        },
+        [processCertificateDownload],
+    )
+
+    const handleRetryDownload = useCallback(() => {
+        if (!downloadVoucherRef) return
+        setDownloadStage('preparing')
+        setDownloadProgress(0)
+        setDownloadOpen(true)
+        processCertificateDownload(downloadVoucherRef)
+    }, [downloadVoucherRef, processCertificateDownload])
+
+    // ── Verify batch payment on Paystack callback ──────────────────────
+    // When Paystack redirects back to `config.bulkRoute?reference=BATCH-…`
+    // (or `?trxref=BATCH-…`), we call the verify endpoint. On a successful
+    // verify, we invalidate the `Students` tag so the cohort refetches
+    // and shows the newly-paid rows; on a failed/pending verify, we toast
+    // and let the agent retry.
+    const reference = searchParams.get('reference') ?? searchParams.get('trxref')
+    const {
+        data: verifyData,
+        isLoading: isVerifying,
+        isSuccess: isVerifySuccess,
+        isError: isVerifyError,
+    } = useVerifyBatchPaymentQuery(reference ?? '', { skip: !reference })
+
+    // Guard so we only react to *one* resolution of the verify query.
+    // Without this, the effect would re-fire on every render that
+    // re-creates `verifyData` (e.g. when the router.replace flushes state).
+    const handledRef = useRef<string | null>(null)
+    useEffect(() => {
+        if (!reference) {
+            handledRef.current = null
+            return
+        }
+        if (handledRef.current === reference) return
+
+        if (isVerifySuccess && verifyData) {
+            const ok =
+                verifyData.statusCode === 200 ||
+                verifyData.statusCode === undefined ||
+                verifyData.paymentStatus === 'successful'
+            if (ok) {
+                handledRef.current = reference
+                const studentCount = getVerifiedStudentCount(verifyData)
+                toast.success(
+                    `Bulk payment confirmed${
+                        studentCount ? ` for ${studentCount} student${studentCount === 1 ? '' : 's'}` : ''
+                    }.`,
+                )
+                // Invalidate every cached `Students` query so the cohort
+                // re-fetches and the newly-paid rows flip to "paid".
+                dispatch(studentApi.util.invalidateTags([{ type: 'Students' }]))
+                // Land the agent on the voucher view. We push the
+                // `?voucher=…` to the URL so the VoucherLookup auto-fetches
+                // and the agent goes straight to the download surface.
+                // If the response didn't carry a voucher ref (older
+                // backend), fall back to scrubbing the URL.
+                if (verifyData.voucherReference) {
+                    // Fetch the full voucher response so we can save it to
+                    // localStorage and display it immediately.
+                    const promise = dispatch(
+                        studentApi.endpoints.getVoucher.initiate(verifyData.voucherReference) as any,
+                    ) as any
+                    promise
+                        .unwrap()
+                        .then(async (voucherResult: VoucherResponse) => {
+                            await saveVoucherToStorage(config.examType, voucherResult)
+                            setSavedVoucher(voucherResult)
+                            setVerifiedAt(new Date().toISOString())
+                            setVoucherRefModal(voucherResult.voucherReference)
+                        })
+                        .catch(() => {
+                            console.warn('Failed to fetch voucher after verify — falling back to URL param.')
+                            const ref = verifyData.voucherReference ?? ''
+                            router.replace(
+                                `${config.bulkRoute}?voucher=${encodeURIComponent(ref)}`,
+                            )
+                        })
+                } else {
+                    router.replace(config.bulkRoute)
+                }
+            } else if (verifyData.paymentStatus === 'pending') {
+                // Paystack's webhook hasn't settled yet. The agent may
+                // have closed the Paystack tab before the backend finished
+                // marking students paid. We mark this reference as handled
+                // (so the effect doesn't re-fire on every render) but
+                // leave the `?reference=...` in the URL — the agent can
+                // refresh the page to re-check, and the verify overlay
+                // will re-appear until the backend confirms.
+                handledRef.current = reference
+                toast(
+                    'Your payment is still being processed. Please refresh this page in a few seconds.',
+                    { icon: '⏳' },
+                )
+            } else {
+                handledRef.current = reference
+                toast.error('Bulk payment was not successful. No charges have been made.')
+                router.replace(config.bulkRoute)
+            }
+        }
+
+        if (isVerifyError) {
+            handledRef.current = reference
+            toast.error('Could not verify the payment. If you were charged, please contact support.')
+            router.replace(config.bulkRoute)
+        }
+    }, [
+        reference,
+        isVerifySuccess,
+        isVerifyError,
+        verifyData,
+        dispatch,
+        router,
+        config.bulkRoute,
+    ])
+
+    // Legacy callback: some backends redirect with `?payment=success/failed`
+    // (without a `reference`). Keep the toast behaviour for that flow but
+    // don't fire the verify call — there's no reference to verify against.
+    useEffect(() => {
+        const status = searchParams.get('payment')
+        if (status && !reference) {
+            if (status === 'success') {
+                toast.success('Bulk payment confirmed. Refreshing the cohort…')
+                dispatch(studentApi.util.invalidateTags([{ type: 'Students' }]))
+            } else if (status === 'failed') {
+                toast.error('Bulk payment failed. No charges have been made.')
+            }
+            router.replace(config.bulkRoute)
+        }
+    }, [searchParams, reference, dispatch, router, config.bulkRoute])
+
+    // ── Render ──────────────────────────────────────────────────────────
+    const showResults = !!appliedFilters
+    const isTableLoading = isLoadingCohort || isFetchingCohort
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex flex-col">
+            <PortalHeader
+                title={`Bulk ${config.shortName} Downloads`}
+                subtitle={config.subtitle}
+                actions={[
+                    {
+                        key: 'switch-exam',
+                        label: 'Switch Exam',
+                        icon: <IoSwapHorizontal className="w-4 h-4" />,
+                        onClick: () =>
+                            router.push(
+                                config.examType === 'bece'
+                                    ? '/result-checking/ubeat/bulk-downloads'
+                                    : '/result-checking/bece/bulk-downloads',
+                            ),
+                        variant: 'secondary',
+                        hideOnMobileTray: true,
+                    },
+                ]}
+            />
+
+            <main className="flex-1 max-w-6xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 pb-32">
+
+                {/* Step 1: Voucher lookup — the primary entry point. Agent
+                    can paste a voucher ref and go straight to download,
+                    bypassing the LGA × School search entirely. Auto-
+                    fetches when `?voucher=…` is in the URL (i.e. after a
+                    successful payment verify pushes it there). The
+                    component has its own hero header. Hidden while the
+                    cohort search is open (mutual exclusion). */}
+                {!cohortExpanded && (
+                    <section className="mb-6">
+                        <VoucherLookup
+                            config={config}
+                            initialValue={urlVoucher}
+                            autoFetch
+                            onDownloadAll={handleVoucherDownloadAll}
+                            onActiveChange={setVoucherActive}
+                            onVoucherLoaded={handleVoucherLoaded}
+                            savedVoucher={savedVoucher}
+                            verifiedAt={verifiedAt}
+                            onClearSaved={handleClearSavedVoucher}
+                        />
+                    </section>
+                )}
+
+                {/* Step 2: Cohort search — collapsible expander. The agent
+                    only needs this when they haven't paid yet. Default
+                    collapsed; auto-expands the first time a search is
+                    submitted. Hidden entirely when a voucher is active
+                    (mutual exclusion). */}
+                {!voucherActive && (
+                    <section className="mb-6">
+                    <button
+                        type="button"
+                        onClick={() => setCohortExpanded(v => !v)}
+                        aria-expanded={cohortExpanded}
+                        aria-controls="cohort-search-panel"
+                        className={[
+                            'group w-full flex items-center justify-between gap-3 px-5 sm:px-6 py-4 rounded-2xl border bg-white transition-colors cursor-pointer text-left',
+                            cohortExpanded
+                                ? 'border-gray-300'
+                                : 'border-gray-200 hover:border-gray-300',
+                        ].join(' ')}
+                    >
+                        <div className="flex items-center gap-3 min-w-0">
+                            <div className="w-9 h-9 rounded-lg bg-gray-100 text-gray-600 flex items-center justify-center flex-shrink-0">
+                                <IoSearch className="w-4 h-4" />
+                            </div>
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-gray-900">
+                                    Don&apos;t have a voucher yet?
+                                </p>
+                                <p className="text-xs text-gray-500 mt-0.5">
+                                    Pay for your school&apos;s certificates first
+                                </p>
+                            </div>
+                        </div>
+                        <IoChevronDown
+                            className={[
+                                'w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-200 group-hover:text-gray-600',
+                                cohortExpanded ? 'rotate-180' : '',
+                            ].join(' ')}
+                        />
+                    </button>
+
+                    {cohortExpanded && (
+                        <div id="cohort-search-panel" className="mt-4 space-y-4">
+                            {/* Search form — only when no search submitted yet */}
+                            {!showResults && (
+                                <BulkSearchForm
+                                    config={config}
+                                    value={filters}
+                                    onChange={setFilters}
+                                    onSubmit={handleSearchSubmit}
+                                    isLoading={isTableLoading}
+                                />
+                            )}
+
+                            {/* Results */}
+                            {showResults && appliedFilters && (
+                                <>
+                                    <SearchFilterSummary
+                                        filters={appliedFilters}
+                                        totalItems={serverTotalItems}
+                                        onEdit={handleChangeFilters}
+                                    />
+
+                                    <StudentResultsTable
+                                        config={config}
+                                        students={students}
+                                        selectedIds={selectedIds}
+                                        onToggleOne={toggleOne}
+                                        isLoading={isTableLoading}
+                                        currentPage={currentPage}
+                                        totalPages={serverTotalPages}
+                                        totalItems={serverTotalItems}
+                                        statusFilteredCount={serverTotalItems}
+                                        matchingCount={students.length}
+                                        itemsPerPage={itemsPerPage}
+                                        onPageChange={handlePageChange}
+                                        onItemsPerPageChange={handleItemsPerPageChange}
+                                        disabled={
+                                            isPaying ||
+                                            downloadStage === 'preparing' ||
+                                            downloadStage === 'downloading'
+                                        }
+                                        onChangeFilters={handleChangeFilters}
+                                        searchQuery={searchQuery}
+                                        onSearchChange={handleSearchInputChange}
+                                        statusFilter={statusFilter}
+                                        onStatusFilterChange={handleStatusFilterChange}
+                                        emptyStateContext={{
+                                            isSearching: searchQuery.trim() !== '',
+                                            searchQuery,
+                                            statusFilter,
+                                            onClearSearch: () => handleSearchInputChange(''),
+                                            onShowAllStatuses: handleShowAllStatuses,
+                                            onSwitchStatus: handleStatusFilterChange,
+                                        }}
+                                    />
+                                </>
+                            )}
+                        </div>
+                    )}
+                </section>
+                )}
+
+                {/* Footer link */}
+                <footer className="mt-8 text-center space-y-2">
+                    <p className="text-xs text-gray-500">
+                        Need a single student instead?{' '}
+                        <Link
+                            href={config.singleStudentRoute}
+                            className="text-gray-900 hover:text-gray-700 font-medium"
+                        >
+                            Go to the standard {config.shortName} portal
+                        </Link>
+                    </p>
+                    <p className="text-xs text-gray-400">
+                        Stuck or lost your voucher? Reach out on the support chat and we&apos;ll
+                        help.
+                    </p>
+                </footer>
+            </main>
+
+            {/* Sticky bulk action bar */}
+            <BulkActionBar
+                config={config}
+                summary={summary}
+                onPay={handleStartPayment}
+                onClearSelection={clearSelection}
+                isProcessing={isPaying || downloadStage === 'preparing'}
+                processingLabel={isPaying ? 'Starting payment…' : 'Preparing ZIP…'}
+            />
+
+            {/* Bulk payment modal */}
+            <BulkPaymentModal
+                open={paymentOpen}
+                onOpenChange={setPaymentOpen}
+                config={config}
+                summary={summary}
+                schoolName={appliedFilters?.school.name ?? ''}
+                onConfirm={handleConfirmPayment}
+            />
+
+            {/* Bulk download modal */}
+            <BulkDownloadModal
+                open={downloadOpen}
+                onOpenChange={(open) => {
+                    setDownloadOpen(open)
+                    if (!open) setDownloadStage('idle')
+                }}
+                config={config}
+                stage={downloadStage}
+                progress={downloadProgress}
+                certificateCount={downloadCertificateCount}
+                onRetry={handleRetryDownload}
+            />
+
+            {/* Verifying-payment overlay — shown when Paystack redirects
+                back with `?reference=…` and the verify call is in flight.
+                Hides automatically when the verify resolves (success or
+                error → `router.replace` scrubs the URL; pending → effect
+                toasts and the overlay remains visible until the agent
+                refreshes the page). */}
+            {reference && isVerifying && (
+                <div
+                    role="status"
+                    aria-live="polite"
+                    className="fixed inset-0 z-50 bg-white/85 backdrop-blur-sm flex items-center justify-center p-4"
+                >
+                    <div className="bg-white rounded-2xl shadow-2xl border border-gray-200 max-w-md w-full overflow-hidden">
+                        <div className="h-1.5 w-full bg-gray-900" />
+                        <div className="p-8 text-center">
+                            <div className="w-16 h-16 rounded-full bg-gray-50 border-2 border-gray-100 mx-auto mb-5 flex items-center justify-center">
+                                <span className="w-8 h-8 border-[3px] border-gray-200 border-t-gray-900 rounded-full animate-spin" />
+                            </div>
+                            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                                Verifying your payment
+                            </h2>
+                            <p className="text-sm text-gray-600 leading-relaxed">
+                                We&apos;re confirming your bulk payment with Paystack. This usually takes a few seconds — please don&apos;t close or refresh this tab.
+                            </p>
+                            <p className="text-[11px] text-gray-400 mt-4 font-mono break-all">
+                                {reference}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Voucher reference copy modal — shown right after a
+                successful payment verification. */}
+            {voucherRefModal && (
+                <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+                    <div className="bg-white rounded-2xl shadow-2xl border border-gray-200 max-w-md w-full overflow-hidden">
+                        <div className="h-1.5 w-full bg-gray-900" />
+                        <div className="p-8 text-center">
+                            <div className="w-16 h-16 rounded-full bg-gray-50 border-2 border-gray-100 mx-auto mb-5 flex items-center justify-center">
+                                <IoCheckmarkCircle className="w-8 h-8 text-gray-900" />
+                            </div>
+                            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                                Payment confirmed!
+                            </h2>
+                            <p className="text-sm text-gray-600 leading-relaxed mb-6">
+                                Broski, this is your voucher reference. Click it to copy.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={handleDismissVoucherModal}
+                                className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-800 transition-colors cursor-pointer"
+                            >
+                                <IoCopyOutline className="w-4 h-4" />
+                                {voucherRefModal}
+                            </button>
+                            <p className="text-[11px] text-gray-400 mt-3">
+                                You&apos;ll need this to download your certificates.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkPaymentModal.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkPaymentModal.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import {
+    IoCardOutline,
+    IoLockClosedOutline,
+    IoMail,
+    IoShieldCheckmarkOutline,
+} from 'react-icons/io5'
+import { isValidEmail } from '@/lib/utils'
+import { formatNaira, type BulkExamConfig } from './examConfig'
+import type { BulkSelectionSummary } from './types'
+import {
+    useSetBecePaymentEmailMutation,
+    useSetUbeatPaymentEmailMutation,
+} from '@/app/result-checking/store/api/studentApi'
+
+interface BulkPaymentModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    config: BulkExamConfig
+    summary: BulkSelectionSummary
+    schoolName: string
+    /**
+     * Called when the agent confirms payment.
+     * The parent POSTs to `/result-payment/create-batch`, sets
+     * `window.location.href = response.authorizationUrl`, and returns the
+     * payment reference (or `undefined` on failure).
+     *
+     * On success the parent will redirect to Paystack; the modal stays
+     * mounted during the brief navigation window so the agent can't
+     * double-click the pay button. On failure the parent returns
+     * `undefined` and the modal resets its submitting state.
+     */
+    onConfirm: (args: { email: string }) => Promise<string | undefined>
+}
+
+/**
+ * Confirmation + receipt-email modal shown before redirecting to Paystack.
+ *
+ * Mirrors the Paywall's `EmailDialog` pattern exactly:
+ *   1. Validate the email
+ *   2. Call `onConfirm({ email })` (parent: createBatchPayment + redirect)
+ *   3. After the parent returns the reference, PATCH the email onto the
+ *      payment using the same `setBecePaymentEmail` / `setUbeatPaymentEmail`
+ *      mutations used by the single-student Paywalls
+ *   4. The email PATCH races the redirect — that's a known characteristic
+ *      of the existing flow, not a bug
+ *
+ * **Sticky loading rule**: once `isSubmitting` is true, it is ONLY reset
+ * on a failure path. A successful `onConfirm` (or successful email set)
+ * leaves `isSubmitting = true` so the Pay button stays disabled until the
+ * page navigation tears the modal down. This prevents the agent from
+ * clicking "Pay" twice and creating two Paystack transactions.
+ */
+export default function BulkPaymentModal({
+    open,
+    onOpenChange,
+    config,
+    summary,
+    schoolName,
+    onConfirm,
+}: BulkPaymentModalProps) {
+    const [email, setEmail] = useState('')
+    const [error, setError] = useState<string | null>(null)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    const [setBecePaymentEmail] = useSetBecePaymentEmailMutation()
+    const [setUbeatPaymentEmail] = useSetUbeatPaymentEmailMutation()
+
+    useEffect(() => {
+        if (open) {
+            setEmail('')
+            setError(null)
+            setIsSubmitting(false)
+            setTimeout(() => inputRef.current?.focus(), 60)
+        }
+    }, [open])
+
+    const handleConfirm = async () => {
+        const trimmed = email.trim()
+
+        if (!trimmed) {
+            setError('Please enter an email for the receipt.')
+            return
+        }
+        if (!isValidEmail(trimmed)) {
+            setError('That doesn\'t look like a valid email address.')
+            return
+        }
+
+        setError(null)
+        // ── Sticky loading: set true ONCE here. From this point on, the
+        // Pay and Cancel buttons are disabled and will not re-enable
+        // until a failure path explicitly resets the state. A successful
+        // `onConfirm` (which triggers window.location.href) does NOT
+        // reset isSubmitting — the modal will be unmounted by the page
+        // navigation before the user ever sees it re-enable.
+        setIsSubmitting(true)
+
+        try {
+            const reference = await onConfirm({ email: trimmed })
+            if (!reference) {
+                // createBatchPayment failed — the parent has already
+                // reset its own loading state and toasted the error.
+                // Re-enable the modal so the agent can retry.
+                setError('Couldn\'t start the payment. Please try again.')
+                setIsSubmitting(false)
+                return
+            }
+
+            // createBatchPayment succeeded and the parent has already
+            // set `window.location.href = response.authorizationUrl`.
+            // PATCH the email onto the payment, racing the redirect.
+            //
+            // ── Sticky loading: the email PATCH happens AFTER the
+            // redirect has been triggered. We do NOT want a PATCH
+            // failure to reset isSubmitting (which would re-enable the
+            // Pay button mid-navigation and could cause a duplicate
+            // payment if the user clicked it again before the page
+            // tears down). The PATCH is best-effort: log the failure
+            // and let the navigation continue.
+            try {
+                const setEmail = config.examType === 'bece' ? setBecePaymentEmail : setUbeatPaymentEmail
+                const result = await setEmail({
+                    email: trimmed,
+                    paymentReference: reference,
+                }).unwrap()
+
+                // Paywall's existing check: any status >= 201 is treated
+                // as a hard error (mirrors the single-student EmailDialog).
+                if (typeof result.status === 'number' && result.status >= 201) {
+                    throw new Error('Email could not be saved on the payment')
+                }
+            } catch (emailErr) {
+                console.warn(
+                    'Receipt email could not be saved on the payment, but the Paystack redirect is already in progress.',
+                    emailErr,
+                )
+                // Intentionally NOT resetting isSubmitting — the page is
+                // about to navigate. The agent will not be able to click
+                // Pay again before the modal is unmounted.
+            }
+
+            // Success: isSubmitting STAYS true. The page navigation will
+            // unmount the modal shortly.
+        } catch (err) {
+            // This catch only fires for the createBatchPayment path (the
+            // email PATCH has its own try/catch above). Reset isSubmitting
+            // so the agent can retry.
+            console.error('Bulk payment confirmation failed', err)
+            setError('Something went wrong. Please try again.')
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={isSubmitting ? undefined : onOpenChange}>
+            <DialogContent className="sm:max-w-md rounded-2xl p-0 overflow-hidden gap-0">
+                <div className="h-1.5 w-full bg-gradient-to-r from-green-500 to-green-600" />
+
+                <div className="p-6">
+                    <DialogHeader className="mb-5">
+                        <div className="flex items-center justify-center w-12 h-12 rounded-full bg-green-50 border border-green-100 mb-4 mx-auto">
+                            <IoCardOutline className="w-6 h-6 text-green-600" aria-hidden="true" />
+                        </div>
+                        <DialogTitle className="text-center text-lg font-semibold text-gray-900">
+                            Confirm bulk payment
+                        </DialogTitle>
+                        <DialogDescription className="text-sm text-gray-500 text-center mt-1 leading-relaxed">
+                            You&apos;re about to pay for {summary.payableCount} {config.shortName}
+                            {' '}result{summary.payableCount === 1 ? '' : 's'} at <span className="capitalize">{schoolName.toLowerCase()}</span>.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {/* Receipt summary */}
+                    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-5 space-y-2.5">
+                        <Row label="Exam" value={config.shortName} />
+                        <Row label="Results to pay for" value={`${summary.payableCount}`} />
+                        <Row label="Price per result" value={formatNaira(config.pricePerStudent)} />
+                        <div className="h-px bg-gray-200 my-2" />
+                        <Row
+                            label="Total amount"
+                            value={formatNaira(summary.totalAmount)}
+                            emphasised
+                        />
+                    </div>
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="bulk-payment-email"
+                            className="block text-sm font-medium text-gray-700 mb-1.5"
+                        >
+                            Receipt email
+                        </label>
+                        <div className="relative">
+                            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <IoMail
+                                    className={`h-5 w-5 transition-colors ${error ? 'text-red-400' : 'text-gray-400'}`}
+                                    aria-hidden="true"
+                                />
+                            </div>
+                            <input
+                                ref={inputRef}
+                                id="bulk-payment-email"
+                                type="email"
+                                value={email}
+                                onChange={(e) => {
+                                    setEmail(e.target.value)
+                                    if (error) setError(null)
+                                }}
+                                placeholder="agent@example.com"
+                                autoComplete="email"
+                                disabled={isSubmitting}
+                                className={[
+                                    'block w-full pl-10 pr-3 py-2.5 text-sm border rounded-lg',
+                                    'focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent transition-colors',
+                                    error ? 'border-red-300 bg-red-50' : 'border-gray-300 hover:border-green-400',
+                                ].join(' ')}
+                            />
+                        </div>
+                        {error && (
+                            <p className="text-xs text-red-600 mt-1.5">{error}</p>
+                        )}
+                        <p className="text-[11px] text-gray-500 mt-1.5 flex items-center gap-1">
+                            <IoShieldCheckmarkOutline className="w-3 h-3" />
+                            We&apos;ll send your bulk receipt and ZIP download link here.
+                        </p>
+                    </div>
+
+                    <DialogFooter className="sm:justify-between gap-2">
+                        <button
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                            disabled={isSubmitting}
+                            className="px-4 py-2.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleConfirm}
+                            disabled={isSubmitting}
+                            className="inline-flex justify-center items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg bg-green-600 hover:bg-green-700 text-white transition-colors shadow-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                    Redirecting…
+                                </>
+                            ) : (
+                                <>
+                                    <IoLockClosedOutline className="w-4 h-4" />
+                                    Pay {formatNaira(summary.totalAmount)}
+                                </>
+                            )}
+                        </button>
+                    </DialogFooter>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+function Row({
+    label,
+    value,
+    emphasised = false,
+}: {
+    label: string
+    value: string
+    emphasised?: boolean
+}) {
+    return (
+        <div className="flex justify-between items-center text-sm">
+            <span className={emphasised ? 'text-gray-700 font-medium' : 'text-gray-500'}>
+                {label}
+            </span>
+            <span
+                className={[
+                    'text-right',
+                    emphasised ? 'text-base font-bold text-green-700' : 'text-gray-900 font-medium',
+                ].join(' ')}
+            >
+                {value}
+            </span>
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkResultsToolbar.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkResultsToolbar.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import React from 'react'
+import { IoClose, IoSearch } from 'react-icons/io5'
+import type { BulkStatusFilter } from './types'
+
+interface BulkResultsToolbarProps {
+    /** Current search input (free-text matches against `studentName`). */
+    searchQuery: string
+    onSearchChange: (value: string) => void
+    /** Active status filter chip. */
+    statusFilter: BulkStatusFilter
+    onStatusFilterChange: (value: BulkStatusFilter) => void
+    /** Total cohort size across all pages (the "All" chip count). */
+    totalCount: number
+    /** Cohort size after applying the status filter (the active chip count). */
+    filteredCount: number
+    /** Cohort size after applying both the status filter and the search. */
+    matchingCount: number
+    /** Whether the chips are interactive. */
+    disabled?: boolean
+}
+
+interface ChipDef {
+    key: BulkStatusFilter
+    label: string
+}
+
+const STATUS_CHIPS: readonly ChipDef[] = [
+    { key: 'all', label: 'All' },
+    { key: 'unpaid', label: 'Unpaid' },
+    { key: 'paid', label: 'Paid' },
+] as const
+
+/**
+ * Toolbar mounted above the bulk results table.
+ *
+ *   [ search ] [ All 340 | Unpaid 340 | Paid 0 ]
+ *
+ * The agent selects rows with the per-row checkboxes. There is no
+ * "Select all" affordance — the server caps the response at the page
+ * size, so any "select all" button that fetched in one call would be
+ * a lie. The agent works one page at a time and accumulates selections
+ * across pages via the cross-page `selectedIds` set.
+ */
+export default function BulkResultsToolbar({
+    searchQuery,
+    onSearchChange,
+    statusFilter,
+    onStatusFilterChange,
+    totalCount,
+    filteredCount,
+    matchingCount,
+    disabled = false,
+}: BulkResultsToolbarProps) {
+    // Per-chip counts for the badge. "Unpaid" and "Paid" show the filtered
+    // count when active (so the chip matches the visible list), and 0
+    // otherwise — the actual breakdown is computed by the parent and the
+    // exact value is shown in the "X of Y match" caption.
+    const chipCount = (key: BulkStatusFilter): number => {
+        if (key === 'all') return totalCount
+        if (statusFilter === key) return filteredCount
+        return 0
+    }
+
+    return (
+        <div className="px-4 sm:px-6 py-3 border-b border-gray-100 bg-gray-50/60 flex flex-col lg:flex-row lg:items-center gap-3">
+            {/* ── Search ──────────────────────────────────────────────── */}
+            <div className="relative flex-1 min-w-0 lg:max-w-sm">
+                <IoSearch className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => onSearchChange(e.target.value)}
+                    placeholder="Search by student name…"
+                    aria-label="Search students"
+                    className="w-full pl-9 pr-9 py-2 text-sm bg-white border border-gray-200 rounded-lg placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-green-500/40 focus:border-green-500 transition-colors"
+                />
+                {searchQuery && (
+                    <button
+                        type="button"
+                        onClick={() => onSearchChange('')}
+                        aria-label="Clear search"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                    >
+                        <IoClose className="w-3.5 h-3.5" />
+                    </button>
+                )}
+            </div>
+
+            {/* ── Status chips ────────────────────────────────────────── */}
+            <div className="inline-flex items-center gap-0.5 bg-white border border-gray-200 rounded-lg p-0.5 self-start lg:self-auto">
+                {STATUS_CHIPS.map(chip => {
+                    const isActive = statusFilter === chip.key
+                    const count = chipCount(chip.key)
+                    return (
+                        <button
+                            key={chip.key}
+                            type="button"
+                            onClick={() => onStatusFilterChange(chip.key)}
+                            disabled={disabled}
+                            className={[
+                                'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all',
+                                'disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer',
+                                isActive
+                                    ? 'bg-green-600 text-white shadow-sm'
+                                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50',
+                            ].join(' ')}
+                        >
+                            <span>{chip.label}</span>
+                            <span
+                                className={[
+                                    'inline-flex items-center justify-center min-w-[1.25rem] px-1 h-4 text-[10px] font-semibold rounded-full tabular-nums',
+                                    isActive
+                                        ? 'bg-white/20 text-white'
+                                        : 'bg-gray-100 text-gray-600',
+                                ].join(' ')}
+                            >
+                                {count}
+                            </span>
+                        </button>
+                    )
+                })}
+            </div>
+
+            {/* ── Spacer + match caption ──────────────────────────────── */}
+            <div className="lg:ml-auto flex items-center gap-2">
+                {searchQuery || statusFilter !== 'all' ? (
+                    <span className="text-[11px] text-gray-500 hidden sm:inline">
+                        {matchingCount === 0
+                            ? 'No matches'
+                            : `${matchingCount} of ${totalCount} match`}
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/BulkSearchForm.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/BulkSearchForm.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { IoBusinessOutline, IoCalendarOutline, IoLocationOutline, IoSearch } from 'react-icons/io5'
+import CustomDropdown from '@/app/portal/dashboard/components/CustomDropdown'
+import { useGetSchoolNamesQuery } from '@/app/portal/store/api/authApi'
+import { useGetAvailableYearsQuery } from '@/app/result-checking/store/api/studentApi'
+import { LGA_OPTIONS } from './mockData'
+import type { BulkExamConfig } from './examConfig'
+import type { BulkSearchFilters } from './types'
+
+interface BulkSearchFormProps {
+    config: BulkExamConfig
+    value: BulkSearchFilters
+    onChange: (value: BulkSearchFilters) => void
+    onSubmit: () => void
+    isLoading?: boolean
+    disabled?: boolean
+}
+
+/**
+ * 3-field search form: Year + LGA + School.
+ * Mirrors the alternative-form pattern from the main BECE/UBEAT login:
+ *   - LGA list is the same `LgaEnum`-derived `LGA_OPTIONS` constant
+ *   - Years are pulled live via `useGetAvailableYearsQuery({ examType })`
+ *   - Schools are pulled live via `useGetSchoolNamesQuery({ lga })`
+ *   - Same "select an LGA before schools become available" affordance
+ *   - Same loading + "no data" empty states
+ */
+export default function BulkSearchForm({
+    config,
+    value,
+    onChange,
+    onSubmit,
+    isLoading = false,
+    disabled = false,
+}: BulkSearchFormProps) {
+    // ── Live available years (per exam) ──────────────────────────────────
+    const { data: yearsData, isLoading: isLoadingYears } = useGetAvailableYearsQuery({
+        examType: config.examType,
+    })
+
+    const yearOptions = useMemo(
+        () => (yearsData?.years ?? []).map(y => ({ value: String(y), label: String(y) })),
+        [yearsData],
+    )
+
+    // ── Live school list (LGA-scoped) ────────────────────────────────────
+    const { data: schoolNames, isLoading: isLoadingSchools, isFetching: isFetchingSchools } =
+        useGetSchoolNamesQuery(
+            { lga: value.lga },
+            { skip: !value.lga },
+        )
+
+    const schoolNamesList = useMemo(() => schoolNames ?? [], [schoolNames])
+
+    const schoolOptions = useMemo(
+        () =>
+            schoolNamesList.map(school => ({
+                value: school._id,
+                label: String(school.schoolName).startsWith('"')
+                    ? String(school.schoolName).slice(1)
+                    : school.schoolName,
+            })),
+        [schoolNamesList],
+    )
+
+    const isFormValid =
+        value.examYear.trim().length === 4 &&
+        value.lga.trim().length >= 2 &&
+        value.school.id.trim().length > 0
+
+    const handleLgaChange = (lga: string) => {
+        // Reset school when LGA changes — mirrors the UBEAT alternative form.
+        onChange({ ...value, lga, school: { id: '', name: '' } })
+    }
+
+    const handleSchoolChange = (schoolId: string) => {
+        const match = schoolNamesList.find(s => s._id === schoolId)
+        onChange({
+            ...value,
+            school: { id: schoolId, name: match?.schoolName ?? '' },
+        })
+    }
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!isFormValid || isLoading || disabled) return
+        onSubmit()
+    }
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            className="bg-white rounded-3xl border border-gray-200 overflow-hidden"
+            aria-label={`Search ${config.shortName} cohort`}
+        >
+            <div className="border-b border-gray-100 px-6 py-4 flex items-center justify-between">
+                <div>
+                    <h3 className="text-sm font-semibold text-gray-900">
+                        Find a {config.shortName} cohort
+                    </h3>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                        Pick a year, LGA and school to load every student in that group.
+                    </p>
+                </div>
+            </div>
+
+            <div className="p-6 grid grid-cols-1 md:grid-cols-3 gap-5">
+                {/* Exam Year */}
+                <div className="group">
+                    <label
+                        htmlFor="bulk-exam-year"
+                        className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2"
+                    >
+                        <IoCalendarOutline className="w-4 h-4 text-gray-400" />
+                        Exam Year <span className="text-red-500">*</span>
+                    </label>
+                    {isLoadingYears ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            <div className="flex items-center gap-2">
+                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+                                <span>Loading years…</span>
+                            </div>
+                        </div>
+                    ) : yearOptions.length === 0 ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            No years available for this exam yet
+                        </div>
+                    ) : (
+                        <CustomDropdown
+                            options={yearOptions}
+                            value={value.examYear}
+                            onChange={year => onChange({ ...value, examYear: year })}
+                            placeholder="Select exam year"
+                        />
+                    )}
+                </div>
+
+                {/* LGA */}
+                <div className="group">
+                    <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2">
+                        <IoLocationOutline className="w-4 h-4 text-gray-400" />
+                        Local Government Area <span className="text-red-500">*</span>
+                    </label>
+                    <CustomDropdown
+                        options={LGA_OPTIONS}
+                        value={value.lga}
+                        onChange={handleLgaChange}
+                        placeholder="Select LGA"
+                        searchable
+                        searchPlaceholder="Search LGA..."
+                    />
+                </div>
+
+                {/* School */}
+                <div className="group">
+                    <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 mb-2">
+                        <IoBusinessOutline className="w-4 h-4 text-gray-400" />
+                        School Name <span className="text-red-500">*</span>
+                    </label>
+                    {!value.lga ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            Select an LGA first
+                        </div>
+                    ) : isLoadingSchools || isFetchingSchools ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            <div className="flex items-center gap-2">
+                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+                                <span>Loading {value.lga} schools…</span>
+                            </div>
+                        </div>
+                    ) : schoolOptions.length === 0 ? (
+                        <div className="w-full bg-gray-50 border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-500">
+                            No schools available for this LGA
+                        </div>
+                    ) : (
+                        <CustomDropdown
+                            options={schoolOptions}
+                            value={value.school.id}
+                            onChange={handleSchoolChange}
+                            placeholder="Select a school"
+                            searchable
+                            searchPlaceholder="Search school name..."
+                        />
+                    )}
+                </div>
+            </div>
+
+            {/* Submit */}
+            <div className="px-6 pb-6 flex flex-col sm:flex-row items-stretch sm:items-center sm:justify-between gap-3">
+                <p className="text-xs text-gray-500 flex items-center gap-1.5">
+                    <IoSearch className="w-3.5 h-3.5" />
+                    Results are paginated 10 per page. You can change filters at any time.
+                </p>
+                <button
+                    type="submit"
+                    disabled={!isFormValid || isLoading || disabled}
+                    className={[
+                        'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold',
+                        'text-white bg-gray-900 hover:bg-gray-800 transition-colors',
+                        'disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer',
+                    ].join(' ')}
+                >
+                    {isLoading ? (
+                        <>
+                            <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                            Loading cohort…
+                        </>
+                    ) : (
+                        <>
+                            <IoSearch className="w-4 h-4" />
+                            Load cohort
+                        </>
+                    )}
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/EmptyState.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/EmptyState.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import React from 'react'
+import { IoFilterOutline, IoSearchCircleOutline } from 'react-icons/io5'
+import type { BulkStatusFilter } from './types'
+
+interface EmptyStateProps {
+    /** Triggered by the "Try different filters" CTA — used when the *whole* cohort is empty. */
+    onChangeFilters: () => void
+
+    /**
+     * Optional context that unlocks in-place recovery actions. If provided,
+     * `EmptyState` treats the user as "filtered into a dead-end" (the cohort
+     * has data, the user's filter just doesn't match any of it) and offers
+     * buttons to clear the search / switch status / show all without ever
+     * leaving the results screen.
+     */
+    context?: {
+        /** Cohort size before any user-applied filter / search. */
+        totalCohort: number
+        /** Cohort size after the status filter (but before the search). */
+        statusFilteredCount: number
+        /** True if a search query is currently typed in the toolbar. */
+        isSearching: boolean
+        /** Current search query (used in the heading). */
+        searchQuery: string
+        /** Current status filter (used to compute the "switch to other" CTA). */
+        statusFilter: BulkStatusFilter
+        /** Clear the in-table search input. */
+        onClearSearch: () => void
+        /** Set the status filter back to 'all'. */
+        onShowAllStatuses: () => void
+        /** Switch to a specific status filter (e.g. the "other" one). */
+        onSwitchStatus: (status: BulkStatusFilter) => void
+    }
+}
+
+const OTHER_STATUS: Record<Exclude<BulkStatusFilter, 'all'>, BulkStatusFilter> = {
+    unpaid: 'paid',
+    paid: 'unpaid',
+}
+
+const STATUS_LABEL: Record<BulkStatusFilter, string> = {
+    all: 'All',
+    unpaid: 'Unpaid',
+    paid: 'Paid',
+}
+
+/**
+ * Shown when a search has been run but the (filtered) cohort is empty.
+ *
+ * Two distinct presentations:
+ *
+ *   1. **No cohort at all** (`context` absent or `totalCohort === 0`) —
+ *      render a full-card message and a single CTA that takes the user
+ *      back to the search form.
+ *
+ *   2. **Filtered into a dead-end** (`context` present and
+ *      `totalCohort > 0`) — render an in-card message and up to three
+ *      one-click recovery buttons (Show all / Clear search / Switch
+ *      status) so the user can recover without leaving the page.
+ */
+export default function EmptyState({
+    onChangeFilters,
+    context,
+}: EmptyStateProps) {
+    const isFilterDeadEnd = !!context && context.totalCohort > 0
+
+    if (!isFilterDeadEnd) {
+        return (
+            <div className="bg-white rounded-3xl border border-gray-200 px-6 py-12 text-center">
+                <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-amber-50 border border-amber-100 flex items-center justify-center">
+                    <IoSearchCircleOutline className="w-8 h-8 text-amber-500" />
+                </div>
+                <h3 className="text-base font-semibold text-gray-900 mb-2">
+                    No students found for that combination
+                </h3>
+                <p className="text-sm text-gray-600 max-w-md mx-auto mb-6">
+                    This school may not have any approved results for the selected year, or the cohort hasn't been uploaded yet. Try adjusting your filters.
+                </p>
+                <button
+                    type="button"
+                    onClick={onChangeFilters}
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-green-700 bg-green-50 hover:bg-green-100 border border-green-100 transition-colors cursor-pointer"
+                >
+                    Try different filters
+                </button>
+            </div>
+        )
+    }
+
+    // ── Filtered-into-a-dead-end case ────────────────────────────────────
+    const {
+        totalCohort,
+        isSearching,
+        searchQuery,
+        statusFilter,
+        onClearSearch,
+        onShowAllStatuses,
+        onSwitchStatus,
+    } = context!
+
+    const isFilteringByStatus = statusFilter !== 'all'
+    const otherStatus = isFilteringByStatus ? OTHER_STATUS[statusFilter] : null
+    // Every student is either paid or unpaid (see bulkApiAdapter), so the
+    // "other" count is just the complement of the current filtered count.
+    const otherStatusCount = isFilteringByStatus
+        ? totalCohort - context!.statusFilteredCount
+        : 0
+
+    const heading = (() => {
+        if (isSearching && isFilteringByStatus) {
+            return `No ${STATUS_LABEL[statusFilter].toLowerCase()} students match "${searchQuery.trim()}"`
+        }
+        if (isSearching) {
+            return `No students match "${searchQuery.trim()}"`
+        }
+        if (isFilteringByStatus) {
+            return `No ${STATUS_LABEL[statusFilter].toLowerCase()} students in this cohort`
+        }
+        return 'No students to show'
+    })()
+
+    return (
+        <div className="px-6 py-12 text-center">
+            <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-blue-50 border border-blue-100 flex items-center justify-center">
+                <IoFilterOutline className="w-8 h-8 text-blue-500" />
+            </div>
+            <h3 className="text-base font-semibold text-gray-900 mb-2">
+                {heading}
+            </h3>
+            <p className="text-sm text-gray-600 max-w-md mx-auto mb-6">
+                The cohort has <span className="font-semibold text-gray-900">{totalCohort}</span> student{totalCohort === 1 ? '' : 's'} total. Try one of the options below to widen the view.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                    type="button"
+                    onClick={onShowAllStatuses}
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-green-600 hover:bg-green-700 border border-green-600 transition-colors cursor-pointer"
+                >
+                    Show all {totalCohort} student{totalCohort === 1 ? '' : 's'}
+                </button>
+                {isSearching && (
+                    <button
+                        type="button"
+                        onClick={onClearSearch}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 border border-gray-200 transition-colors cursor-pointer"
+                    >
+                        Clear search
+                    </button>
+                )}
+                {otherStatus && otherStatusCount > 0 && (
+                    <button
+                        type="button"
+                        onClick={() => onSwitchStatus(otherStatus)}
+                        title={`Show the ${otherStatusCount} ${STATUS_LABEL[otherStatus].toLowerCase()} student${otherStatusCount === 1 ? '' : 's'} instead`}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 border border-gray-200 transition-colors cursor-pointer"
+                    >
+                        View {otherStatusCount} {STATUS_LABEL[otherStatus].toLowerCase()}
+                    </button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/LoadingState.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/LoadingState.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React from 'react'
+
+interface LoadingStateProps {
+    /** Number of skeleton rows to render — keep close to itemsPerPage. */
+    rows?: number
+}
+
+/**
+ * Skeleton loader styled to match the dimensions of the loaded table,
+ * so the layout doesn't jump once data arrives.
+ */
+export default function LoadingState({ rows = 8 }: LoadingStateProps) {
+    return (
+        <div className="bg-white rounded-3xl border border-gray-200 overflow-hidden">
+            <div className="border-b border-gray-100 px-6 py-4">
+                <div className="h-4 w-48 bg-gray-200 rounded animate-pulse mb-2" />
+                <div className="h-3 w-72 bg-gray-100 rounded animate-pulse" />
+            </div>
+
+            <div className="divide-y divide-gray-100">
+                {Array.from({ length: rows }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-4 px-6 py-4">
+                        <div className="w-4 h-4 rounded bg-gray-200 animate-pulse flex-shrink-0" />
+                        <div className="w-6 h-3 rounded bg-gray-100 animate-pulse flex-shrink-0" />
+
+                        <div className="flex-1 min-w-0 space-y-2">
+                            <div className="h-3 w-1/3 bg-gray-200 rounded animate-pulse" />
+                            <div className="h-2.5 w-1/4 bg-gray-100 rounded animate-pulse" />
+                        </div>
+
+                        <div className="hidden md:block h-3 w-24 bg-gray-100 rounded animate-pulse" />
+                        <div className="hidden md:block h-3 w-12 bg-gray-100 rounded animate-pulse" />
+                        <div className="h-5 w-16 rounded-full bg-gray-100 animate-pulse" />
+                        <div className="hidden sm:block h-6 w-20 rounded-md bg-gray-100 animate-pulse" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/PaymentStatusBadge.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/PaymentStatusBadge.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React from 'react'
+import { IoCheckmarkCircle, IoHourglass, IoAlertCircle } from 'react-icons/io5'
+import type { BulkPaymentStatus } from './types'
+
+interface PaymentStatusBadgeProps {
+    status: BulkPaymentStatus
+    /** Compact variant used inside dense tables. */
+    size?: 'sm' | 'md'
+}
+
+const STATUS_STYLES: Record<BulkPaymentStatus, { icon: React.ReactNode; label: string; className: string }> = {
+    paid: {
+        icon: <IoCheckmarkCircle className="w-3.5 h-3.5" />,
+        label: 'Paid',
+        className: 'bg-green-50 text-green-700 border-green-200',
+    },
+    pending: {
+        icon: <IoHourglass className="w-3.5 h-3.5 animate-pulse" />,
+        label: 'Pending',
+        className: 'bg-amber-50 text-amber-700 border-amber-200',
+    },
+    unpaid: {
+        icon: <IoAlertCircle className="w-3.5 h-3.5" />,
+        label: 'Unpaid',
+        className: 'bg-gray-50 text-gray-600 border-gray-200',
+    },
+}
+
+export default function PaymentStatusBadge({ status, size = 'md' }: PaymentStatusBadgeProps) {
+    const style = STATUS_STYLES[status]
+    return (
+        <span
+            className={[
+                'inline-flex items-center gap-1 rounded-full font-semibold border',
+                size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-xs',
+                style.className,
+            ].join(' ')}
+        >
+            {style.icon}
+            {style.label}
+        </span>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/SearchFilterSummary.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/SearchFilterSummary.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React from 'react'
+import { IoBusinessOutline, IoCalendarOutline, IoLocationOutline, IoPencil } from 'react-icons/io5'
+import type { BulkSearchFilters } from './types'
+
+interface SearchFilterSummaryProps {
+    filters: BulkSearchFilters
+    /** Total students returned by the current filters. */
+    totalItems: number
+    /** Called when the agent clicks "Change filters". */
+    onEdit: () => void
+}
+
+/**
+ * Compact summary card shown above the results table once a search has been run.
+ * Lets the agent see at-a-glance what they're looking at and re-open the form.
+ */
+export default function SearchFilterSummary({
+    filters,
+    totalItems,
+    onEdit,
+}: SearchFilterSummaryProps) {
+    return (
+        <div className="bg-white rounded-2xl border border-gray-200 px-4 py-3 sm:px-6 sm:py-4">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+                    <Pill icon={<IoCalendarOutline className="w-4 h-4" />} label="Year" value={filters.examYear} />
+                    <Pill icon={<IoLocationOutline className="w-4 h-4" />} label="LGA" value={filters.lga} />
+                    <Pill icon={<IoBusinessOutline className="w-4 h-4" />} label="School" value={filters.school.name} truncate />
+                    <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-green-50 text-green-700 text-xs font-semibold border border-green-100">
+                        {totalItems.toLocaleString()} student{totalItems === 1 ? '' : 's'}
+                    </span>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium text-green-700 bg-green-50 hover:bg-green-100 border border-green-100 transition-colors cursor-pointer"
+                >
+                    <IoPencil className="w-3.5 h-3.5" />
+                    Change filters
+                </button>
+            </div>
+        </div>
+    )
+}
+
+function Pill({
+    icon,
+    label,
+    value,
+    truncate = false,
+}: {
+    icon: React.ReactNode
+    label: string
+    value: string
+    truncate?: boolean
+}) {
+    return (
+        <span className="inline-flex items-center gap-2 min-w-0">
+            <span className="flex-shrink-0 text-gray-400">{icon}</span>
+            <span className="flex-shrink-0 text-xs uppercase tracking-wide text-gray-500">{label}</span>
+            <span className={[
+                'text-sm font-semibold text-gray-900 capitalize',
+                truncate ? 'truncate max-w-[200px] sm:max-w-[300px]' : '',
+            ].join(' ')}>
+                {(value || '—').toLowerCase()}
+            </span>
+        </span>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/StudentResultsRow.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/StudentResultsRow.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import React from 'react'
+import PaymentStatusBadge from './PaymentStatusBadge'
+import { toTitleCase } from './format'
+import type { BulkStudent } from './types'
+import type { BulkExamConfig } from './examConfig'
+
+interface StudentResultsRowProps {
+    student: BulkStudent
+    /** Global index across pages — used for serial numbers. */
+    serial: number
+    checked: boolean
+    onToggle: (id: string, event: React.MouseEvent) => void
+    config: BulkExamConfig
+    /** Disable inputs while a bulk action is running. */
+    disabled?: boolean
+}
+
+/**
+ * Single row of the bulk students table.
+ * Renders both as a desktop table row and a mobile card via responsive
+ * Tailwind classes — see `StudentResultsTable` for the desktop wrapper.
+ *
+ * The backend contract (`POST /{examType}/students/by-school`) only returns
+ * `{ _id, name, isPaid }`, so the table is intentionally narrow: serial,
+ * student name, and payment status.
+ */
+export default function StudentResultsRow({
+    student,
+    serial,
+    checked,
+    onToggle,
+    config,
+    disabled = false,
+}: StudentResultsRowProps) {
+    const isPaid = student.paymentStatus === 'paid'
+
+    const handleToggle = (e: React.MouseEvent) => {
+        if (disabled || isPaid) return
+        e.stopPropagation()
+        onToggle(student._id, e)
+    }
+
+    return (
+        <>
+            {/* ── Desktop row ─────────────────────────────────────────── */}
+            <tr
+                className={[
+                    'hidden md:table-row border-b border-gray-100 transition-colors',
+                    isPaid ? 'opacity-50' : checked ? 'bg-green-50/40' : 'hover:bg-gray-50',
+                ].join(' ')}
+            >
+                <td className="px-4 py-3 align-middle">
+                    <label className={isPaid ? 'inline-flex items-center' : 'inline-flex items-center cursor-pointer'}>
+                        <input
+                            type="checkbox"
+                            checked={checked}
+                            onClick={handleToggle}
+                            disabled={disabled || isPaid}
+                            className="w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 disabled:cursor-not-allowed"
+                            aria-label={`Select ${student.studentName}`}
+                        />
+                    </label>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-500 align-middle">{serial}</td>
+                <td className="px-4 py-3 align-middle">
+                    <p className="text-sm font-semibold text-gray-900">
+                        {toTitleCase(student.studentName)}
+                    </p>
+                </td>
+                <td className="px-4 py-3 align-middle">
+                    <PaymentStatusBadge status={student.paymentStatus} />
+                </td>
+            </tr>
+
+            {/* ── Mobile card ─────────────────────────────────────────── */}
+            <tr className="md:hidden">
+                <td colSpan={4} className="px-3 py-2">
+                    <div
+                        className={[
+                            'flex items-start gap-3 p-3 rounded-xl border transition-colors',
+                            isPaid ? 'opacity-50 bg-gray-50 border-gray-200' : checked ? 'bg-green-50/60 border-green-200' : 'bg-white border-gray-200',
+                        ].join(' ')}
+                    >
+                        <input
+                            type="checkbox"
+                            checked={checked}
+                            onClick={handleToggle}
+                            disabled={disabled || isPaid}
+                            className="mt-1 w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 disabled:cursor-not-allowed flex-shrink-0"
+                            aria-label={`Select ${student.studentName}`}
+                        />
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2">
+                                <p className="text-sm font-semibold text-gray-900 truncate">
+                                    {toTitleCase(student.studentName)}
+                                </p>
+                                <PaymentStatusBadge status={student.paymentStatus} size="sm" />
+                            </div>
+                            <p className="text-[11px] text-gray-500 mt-0.5">
+                                #{serial}
+                            </p>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/StudentResultsTable.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/StudentResultsTable.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import React from 'react'
+import StudentResultsRow from './StudentResultsRow'
+import Pagination from '@/app/portal/dashboard/components/Pagination'
+import LoadingState from './LoadingState'
+import EmptyState from './EmptyState'
+import BulkResultsToolbar from './BulkResultsToolbar'
+import type { BulkStatusFilter, BulkStudent } from './types'
+import type { BulkExamConfig } from './examConfig'
+
+interface StudentResultsTableProps {
+    config: BulkExamConfig
+    students: BulkStudent[]
+    selectedIds: Set<string>
+    onToggleOne: (id: string, event: React.MouseEvent) => void
+    isLoading: boolean
+    currentPage: number
+    totalPages: number
+    /** Total cohort size, ignoring search + status filters. */
+    totalItems: number
+    /** Cohort size after the status filter (pre-search). */
+    statusFilteredCount: number
+    /** Cohort size after both status filter + search (== `students.length + offPage`). */
+    matchingCount: number
+    itemsPerPage: number
+    onPageChange: (page: number) => void
+    onItemsPerPageChange: (n: number) => void
+    /** True while a bulk payment / download is in progress. */
+    disabled?: boolean
+    /** Triggered when EmptyState's "Try different filters" CTA is clicked. */
+    onChangeFilters: () => void
+    /** Toolbar props ───────────────────────────────────────────────── */
+    searchQuery: string
+    onSearchChange: (value: string) => void
+    statusFilter: BulkStatusFilter
+    onStatusFilterChange: (value: BulkStatusFilter) => void
+    /** EmptyState context — controls the in-place recovery buttons. */
+    emptyStateContext?: {
+        isSearching: boolean
+        searchQuery: string
+        statusFilter: BulkStatusFilter
+        onClearSearch: () => void
+        onShowAllStatuses: () => void
+        onSwitchStatus: (status: BulkStatusFilter) => void
+    }
+}
+
+/**
+ * Top-level results table.
+ *
+ * Layout invariant: the card chrome (border, header, toolbar) is always
+ * rendered. Only the *body* of the card swaps between three states:
+ *
+ *   1. `<LoadingState>` — initial cohort fetch
+ *   2. `<EmptyState>`   — current filter/search produced zero matches
+ *   3. `<table>`        — happy path, with pagination at the bottom
+ *
+ * Selection is per-row only — the per-page master checkbox was removed
+ * because the server caps the response at the page size, so any "select
+ * all" affordance that didn't fetch additional pages would be a lie.
+ * The agent accumulates selections across pages via the cross-page
+ * `selectedIds` set maintained by the parent.
+ */
+export default function StudentResultsTable({
+    config,
+    students,
+    selectedIds,
+    onToggleOne,
+    isLoading,
+    currentPage,
+    totalPages,
+    totalItems,
+    statusFilteredCount,
+    matchingCount,
+    itemsPerPage,
+    onPageChange,
+    onItemsPerPageChange,
+    disabled = false,
+    onChangeFilters,
+    searchQuery,
+    onSearchChange,
+    statusFilter,
+    onStatusFilterChange,
+    emptyStateContext,
+}: StudentResultsTableProps) {
+    // Cross-page serial numbering — useful when the table spans many pages.
+    const startSerial = (currentPage - 1) * itemsPerPage
+
+    // The toolbar is shown once the cohort is loaded, OR while the user is
+    // actively typing a search / clicking a chip. We don't want to show it
+    // on the very first render before the cohort query has finished.
+    const showToolbar =
+        !isLoading &&
+        (totalItems > 0 || searchQuery !== '' || statusFilter !== 'all')
+
+    const isEmpty = !isLoading && students.length === 0
+
+    return (
+        <div className="bg-white rounded-3xl border border-gray-200 overflow-hidden">
+            {/* Header */}
+            <div className="border-b border-gray-100 px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                    <h3 className="text-sm font-semibold text-gray-900">
+                        Students in this cohort
+                    </h3>
+                    <p className="text-xs text-gray-500 mt-0.5 truncate">
+                        Tick the rows you want to pay for, then use the action bar at the bottom.
+                    </p>
+                </div>
+                <span className="hidden sm:inline-flex text-[11px] text-gray-400 tabular-nums">
+                    {selectedIds.size} selected
+                </span>
+            </div>
+
+            {/* Toolbar (search + status filter chips). */}
+            {showToolbar && (
+                <BulkResultsToolbar
+                    searchQuery={searchQuery}
+                    onSearchChange={onSearchChange}
+                    statusFilter={statusFilter}
+                    onStatusFilterChange={onStatusFilterChange}
+                    totalCount={totalItems}
+                    filteredCount={statusFilteredCount}
+                    matchingCount={matchingCount}
+                    disabled={disabled}
+                />
+            )}
+
+            {/* Body */}
+            {isLoading ? (
+                <LoadingState rows={itemsPerPage} />
+            ) : isEmpty ? (
+                <EmptyState
+                    onChangeFilters={onChangeFilters}
+                    context={
+                        emptyStateContext
+                            ? {
+                                totalCohort: totalItems,
+                                statusFilteredCount,
+                                ...emptyStateContext,
+                            }
+                            : undefined
+                    }
+                />
+            ) : (
+                <>
+                    {/* Table */}
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full">
+                            {/* ── Desktop column headers ─────────────────────── */}
+                            <thead className="hidden md:table-header-group bg-gray-50 border-b border-gray-100">
+                                <tr>
+                                    <th className="px-4 py-3 text-left w-10">
+                                        <span
+                                            className="inline-block w-4 h-4"
+                                            aria-hidden
+                                        />
+                                    </th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide w-12">#</th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide">Student</th>
+                                    <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wide">Status</th>
+                                </tr>
+                            </thead>
+
+                            {/* ── Mobile header spacer ─────────────────────── */}
+                            <thead className="md:hidden">
+                                <tr>
+                                        <th colSpan={4} className="px-3 py-2 bg-gray-50 border-b border-gray-100 text-[11px] text-gray-500">
+                                            Tick rows to select · {selectedIds.size} selected
+                                        </th>
+                                    </tr>
+                                </thead>
+
+                                <tbody className="md:divide-y md:divide-gray-100">
+                                    {students.map((student, index) => (
+                                        <StudentResultsRow
+                                            key={student._id}
+                                            student={student}
+                                            serial={startSerial + index + 1}
+                                            checked={selectedIds.has(student._id)}
+                                            onToggle={onToggleOne}
+                                            config={config}
+                                            disabled={disabled}
+                                        />
+                                    ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Pagination */}
+                    <div className="px-4 sm:px-6 pt-2 pb-4 border-t border-gray-100">
+                        <Pagination
+                            currentPage={currentPage}
+                            totalPages={totalPages}
+                            itemsPerPage={itemsPerPage}
+                            totalItems={totalItems}
+                            onPageChange={onPageChange}
+                            onItemsPerPageChange={onItemsPerPageChange}
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/VoucherLookup.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/VoucherLookup.tsx
@@ -1,0 +1,562 @@
+'use client'
+
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+    IoAlertCircleOutline,
+    IoBusinessOutline,
+    IoCalendarOutline,
+    IoCardOutline,
+    IoCheckmarkCircle,
+    IoChevronDown,
+    IoCopyOutline,
+    IoDownloadOutline,
+    IoHelpCircleOutline,
+    IoLocationOutline,
+    IoLogOutOutline,
+    IoReceiptOutline,
+    IoRefresh,
+    IoSearch,
+} from 'react-icons/io5'
+import toast from 'react-hot-toast'
+import { useLazyGetVoucherQuery, getVoucherDownloadableIds } from '@/app/result-checking/store/api/studentApi'
+import { type BulkExamConfig } from './examConfig'
+import { toTitleCase } from './format'
+import type { VoucherResponse } from '@/app/result-checking/store/api/studentApi'
+
+interface VoucherLookupProps {
+    config: BulkExamConfig
+    initialValue?: string
+    autoFetch?: boolean
+    onDownloadAll: (paidIds: string[], voucher: VoucherResponse) => void
+    onActiveChange?: (active: boolean) => void
+    onVoucherLoaded?: (voucher: VoucherResponse) => void
+    savedVoucher?: VoucherResponse | null
+    verifiedAt?: string | null
+    onClearSaved?: () => void
+}
+
+export default function VoucherLookup({
+    config,
+    initialValue,
+    autoFetch = false,
+    onDownloadAll,
+    onActiveChange,
+    savedVoucher,
+    verifiedAt,
+    onClearSaved,
+    onVoucherLoaded,
+}: VoucherLookupProps) {
+    const [reference, setReference] = useState(initialValue ?? '')
+    const [showHelp, setShowHelp] = useState(false)
+    const [trigger, { data: voucher, isLoading, isError, error, reset }] =
+        useLazyGetVoucherQuery()
+
+    const autoFetchedRef = useRef<string | null>(null)
+
+    const displayVoucher = savedVoucher ?? voucher
+    const isFromStorage = !!savedVoucher
+
+    useEffect(() => {
+        if (initialValue && initialValue !== reference) {
+            setReference(initialValue)
+            reset()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialValue])
+
+    useEffect(() => {
+        if (savedVoucher) return
+        if (
+            autoFetch &&
+            initialValue &&
+            initialValue.trim() &&
+            autoFetchedRef.current !== initialValue
+        ) {
+            autoFetchedRef.current = initialValue
+            trigger(initialValue.trim())
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [autoFetch, initialValue, savedVoucher])
+
+    const downloadableIds = useMemo(() => getVoucherDownloadableIds(displayVoucher), [displayVoucher])
+    const downloadableCount = downloadableIds.length
+    const paidCount = useMemo(
+        () => (displayVoucher?.studentIds ?? []).filter(s => s.isPaid).length,
+        [displayVoucher],
+    )
+
+    const handleSubmit = (e?: React.FormEvent) => {
+        e?.preventDefault()
+        const trimmed = reference.trim()
+        if (!trimmed) {
+            toast.error('Please paste your voucher reference first.')
+            return
+        }
+        autoFetchedRef.current = trimmed
+        trigger(trimmed)
+    }
+
+    useEffect(() => {
+        if (savedVoucher) {
+            onActiveChange?.(true)
+            return
+        }
+        onActiveChange?.(!!(voucher && !isLoading))
+    }, [voucher, isLoading, onActiveChange, savedVoucher])
+
+    useEffect(() => {
+        if (voucher && !savedVoucher && onVoucherLoaded) {
+            onVoucherLoaded(voucher)
+        }
+    }, [voucher, savedVoucher, onVoucherLoaded])
+
+    const handleReset = () => {
+        setReference('')
+        autoFetchedRef.current = null
+        reset()
+        onActiveChange?.(false)
+    }
+
+    const errorMessage =
+        isError && error && typeof error === 'object' && 'data' in error
+            ? (error as { data?: { message?: string } }).data?.message
+            : isError
+                ? (error as { message?: string })?.message ??
+                  "We couldn't find that voucher. Please check the reference and try again."
+                : null
+
+    const copy = async (text: string, label: string) => {
+        try {
+            await navigator.clipboard.writeText(text)
+            toast.success(`${label} copied.`)
+        } catch {
+            toast.error('Could not copy to clipboard.')
+        }
+    }
+
+    const VoucherMetric = ({ count, label, statusText, statusColor, amount }: {
+        count: number; label: string; statusText: string; statusColor: string; amount?: number
+    }) => (
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-5">
+            <div>
+                <div className="flex items-baseline gap-3">
+                    <span className="text-5xl sm:text-7xl font-bold text-gray-900 tracking-tight tabular-nums leading-none">
+                        {count}
+                    </span>
+                    <span className="text-base sm:text-lg text-gray-500 font-medium">
+                        {label}
+                    </span>
+                </div>
+                <div className="flex items-center gap-2 mt-3">
+                    <div className={`w-2 h-2 rounded-full ${statusColor}`} />
+                    <span className="text-sm text-gray-500">{statusText}</span>
+                </div>
+            </div>
+            {amount !== undefined && (
+                <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl bg-gray-50 border border-gray-200">
+                    <div className="text-right">
+                        <p className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">Total paid</p>
+                        <p className="text-xl font-bold text-gray-900 tabular-nums mt-0.5">
+                            ₦{amount.toLocaleString('en-NG')}
+                        </p>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+
+    const VoucherDetails = ({ voucher }: { voucher: VoucherResponse }) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 text-sm">
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoBusinessOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">School</p>
+                    <p className="font-medium text-gray-900 truncate">{toTitleCase(voucher.schoolName)}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoLocationOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">LGA</p>
+                    <p className="font-medium text-gray-900 truncate">{voucher.lga}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoReceiptOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Exam</p>
+                    <p className="font-medium text-gray-900">{voucher.examType} &middot; {voucher.examYear}</p>
+                </div>
+            </div>
+            <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoCalendarOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Issued</p>
+                    <p className="font-medium text-gray-900">
+                        {new Date(voucher.createdAt).toLocaleDateString('en-NG', {
+                            year: 'numeric', month: 'short', day: 'numeric',
+                        })}
+                    </p>
+                </div>
+            </div>
+            <div className="sm:col-span-2 flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <IoCardOutline className="w-4 h-4 text-gray-500" />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-xs text-gray-500">Voucher reference</p>
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => copy(voucher.voucherReference, 'Voucher reference')}
+                            className="group inline-flex items-center gap-1.5"
+                            title="Click to copy"
+                        >
+                            <span className="font-mono text-sm font-medium text-gray-900 truncate">
+                                {voucher.voucherReference}
+                            </span>
+                            <IoCopyOutline className="w-3.5 h-3.5 text-gray-400 group-hover:text-gray-900 transition-colors flex-shrink-0" />
+                        </button>
+                        {voucher.paymentReference && (
+                            <>
+                                <span className="text-gray-300 mx-1">&middot;</span>
+                                <button
+                                    type="button"
+                                    onClick={() => copy(voucher.paymentReference, 'Payment reference')}
+                                    className="group inline-flex items-center gap-1.5"
+                                    title="Click to copy"
+                                >
+                                    <span className="font-mono text-xs text-gray-500 truncate">
+                                        {voucher.paymentReference}
+                                    </span>
+                                    <IoCopyOutline className="w-3 h-3 text-gray-300 group-hover:text-gray-900 transition-colors flex-shrink-0" />
+                                </button>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+
+    const StudentList = ({ voucher }: { voucher: VoucherResponse }) => (
+        <div>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-semibold text-gray-900">Students included</h3>
+                <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full font-medium">
+                    {downloadableCount} {downloadableCount === 1 ? 'student' : 'students'}
+                </span>
+            </div>
+            <div className="border border-gray-100 rounded-xl overflow-hidden divide-y divide-gray-100">
+                {voucher.studentIds
+                    .filter(s => s.isPaid)
+                    .map((s, i) => (
+                        <div key={s._id} className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50/80 transition-colors">
+                            <span className="text-xs text-gray-400 tabular-nums font-medium w-6 text-right flex-shrink-0">
+                                {String(i + 1).padStart(2, '0')}
+                            </span>
+                            <div className="flex-1 min-w-0">
+                                <p className="text-gray-900 truncate font-medium">
+                                    {s.studentName || (
+                                        <span className="italic text-gray-400 font-normal">Name unavailable</span>
+                                    )}
+                                </p>
+                            </div>
+                            <span className="text-[11px] text-gray-400 font-mono">{s._id.slice(-8)}</span>
+                        </div>
+                    ))}
+            </div>
+        </div>
+    )
+
+    const DownloadSection = ({ count, voucher }: { count: number; voucher: VoucherResponse }) => (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+                <p className="text-sm font-semibold text-gray-900">
+                    Download all {count} {count === 1 ? 'certificate' : 'certificates'}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">Saves as a single .zip file</p>
+            </div>
+            <button
+                type="button"
+                onClick={() => onDownloadAll(downloadableIds, voucher)}
+                className="inline-flex items-center justify-center gap-2 h-11 px-6 rounded-xl text-sm font-semibold bg-gray-900 text-white hover:bg-gray-800 active:scale-[0.97] transition-all cursor-pointer"
+            >
+                <IoDownloadOutline className="w-4 h-4" />
+                <span>Download ZIP</span>
+            </button>
+        </div>
+    )
+
+    // ── Render: saved voucher mode ──
+    if (isFromStorage && displayVoucher) {
+        const voucher = displayVoucher
+        return (
+            <section aria-label="Voucher receipt" className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+                {/* Header */}
+                <div className="px-6 sm:px-10 pt-8 sm:pt-10 pb-2 flex items-start justify-between gap-4">
+                    <div>
+                        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+                            Your certificates are ready
+                        </h1>
+                        <p className="mt-1.5 text-sm sm:text-base text-gray-500">
+                            Download your paid {config.certificateLabel.toLowerCase()} certificates below.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClearSaved}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition-colors cursor-pointer flex-shrink-0"
+                        title="Clear saved voucher"
+                    >
+                        <IoLogOutOutline className="w-4 h-4" />
+                        <span className="hidden sm:inline">Clear</span>
+                    </button>
+                </div>
+
+                {/* Success banner */}
+                {verifiedAt && (
+                    <div className="mx-6 sm:mx-10 mt-6 rounded-xl bg-green-50 border border-green-200 overflow-hidden">
+                        <div className="h-1 w-full bg-green-500" />
+                        <div className="p-5 flex items-start gap-4">
+                            <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+                                <IoCheckmarkCircle className="w-5 h-5 text-green-700" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <h3 className="text-sm font-semibold text-green-900">Payment confirmed!</h3>
+                                <p className="text-sm text-green-700 mt-0.5 leading-relaxed">
+                                    Your payment of{' '}
+                                    <span className="font-medium">₦{voucher.amountPaid.toLocaleString('en-NG')}</span>
+                                    {' '}for {voucher.studentCount} {voucher.studentCount === 1 ? 'student' : 'students'}{' '}
+                                    was successful. Your certificates are ready to download.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* Metric */}
+                <div className="px-6 sm:px-10 pt-8 pb-6">
+                    <VoucherMetric
+                        count={downloadableCount}
+                        label={downloadableCount === 1 ? 'certificate' : 'certificates'}
+                        statusText="Ready to download"
+                        statusColor="bg-green-500"
+                        amount={voucher.amountPaid}
+                    />
+                </div>
+
+                {/* Voucher details */}
+                <div className="px-6 sm:px-10 py-6 border-t border-gray-100">
+                    <VoucherDetails voucher={voucher} />
+                </div>
+
+                {/* Students list */}
+                {downloadableCount > 0 && (
+                    <div className="px-6 sm:px-10 pb-6">
+                        <StudentList voucher={voucher} />
+                    </div>
+                )}
+
+                {/* Download CTA */}
+                {downloadableCount > 0 && (
+                    <div className="px-6 sm:px-10 py-6 border-t border-gray-100">
+                        <DownloadSection count={downloadableCount} voucher={voucher} />
+                    </div>
+                )}
+            </section>
+        )
+    }
+
+    // ── Render: normal flow (input form + optional fetch results) ──
+    return (
+        <section aria-label="Voucher receipt" className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+            {/* Header */}
+            <div className="px-6 sm:px-10 pt-8 sm:pt-10 pb-2">
+                <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">
+                    Download your certificates
+                </h1>
+                <p className="mt-1.5 text-sm sm:text-base text-gray-500">
+                    Paste your voucher reference below to get every paid{' '}
+                    {config.certificateLabel.toLowerCase()} in one ZIP file.
+                </p>
+            </div>
+
+            {/* Input row */}
+            <form onSubmit={handleSubmit} aria-label="Voucher lookup" className="px-6 sm:px-10 pt-6 pb-2">
+                <div className="flex flex-col sm:flex-row gap-2">
+                    <div className="relative flex-1 min-w-0">
+                        <IoSearch
+                            aria-hidden
+                            className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                        />
+                        <input
+                            type="text"
+                            inputMode="text"
+                            autoComplete="off"
+                            spellCheck={false}
+                            value={reference}
+                            onChange={e => setReference(e.target.value)}
+                            placeholder="VCH-XXXXXXXXXX-XXXX"
+                            disabled={isLoading}
+                            aria-label="Voucher reference"
+                            className={[
+                                'w-full h-11 pl-10 pr-4 text-sm rounded-xl border bg-white transition-colors font-mono',
+                                'placeholder:text-gray-300 placeholder:font-sans',
+                                'focus:outline-none focus:ring-2 focus:ring-offset-0',
+                                'disabled:bg-gray-50 disabled:cursor-not-allowed',
+                                isError
+                                    ? 'border-red-300 text-red-900 focus:border-red-500 focus:ring-red-500/20'
+                                    : 'border-gray-300 text-gray-900 focus:border-gray-900 focus:ring-gray-900/10',
+                            ].join(' ')}
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={isLoading || !reference.trim()}
+                        className={[
+                            'inline-flex items-center justify-center gap-2 h-11 px-5 rounded-xl text-sm font-semibold transition-all',
+                            'bg-gray-900 text-white hover:bg-gray-800 cursor-pointer',
+                            'disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed',
+                            !isLoading && reference.trim() ? 'active:scale-[0.97]' : '',
+                        ].join(' ')}
+                    >
+                        {isLoading ? (
+                            <>
+                                <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                <span>Finding your certificates&hellip;</span>
+                            </>
+                        ) : (
+                            <span>Get my certificates</span>
+                        )}
+                    </button>
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1.5 text-xs text-gray-500">
+                    <span>
+                        Format:{' '}
+                        <span className="font-mono text-gray-700 font-medium">VCH-XXXXXXXXXX-XXXX</span>
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => setShowHelp(s => !s)}
+                        aria-expanded={showHelp}
+                        className="inline-flex items-center gap-1 text-gray-600 hover:text-gray-900 cursor-pointer font-medium"
+                    >
+                        <IoHelpCircleOutline className="w-3.5 h-3.5" />
+                        <span>Where do I find this?</span>
+                        <IoChevronDown
+                            className={[
+                                'w-3 h-3 transition-transform duration-200',
+                                showHelp ? 'rotate-180' : '',
+                            ].join(' ')}
+                        />
+                    </button>
+                    {(voucher || isError) && !isLoading && (
+                        <button
+                            type="button"
+                            onClick={handleReset}
+                            className="inline-flex items-center gap-1 text-gray-500 hover:text-gray-900 cursor-pointer font-medium"
+                        >
+                            <IoRefresh className="w-3 h-3" />
+                            <span>Use a different voucher</span>
+                        </button>
+                    )}
+                </div>
+
+                {showHelp && (
+                    <div className="mt-3 px-4 py-3 rounded-xl bg-gray-50 border border-gray-200 text-xs text-gray-600 leading-relaxed space-y-1.5">
+                        <p>
+                            After you pay, we send a receipt email with your voucher reference.
+                            It also appears on the payment success page.
+                        </p>
+                        <p>
+                            The reference always starts with{' '}
+                            <span className="font-mono font-medium text-gray-900">VCH-</span>{' '}
+                            followed by numbers.
+                        </p>
+                        <p>
+                            Can&apos;t find it? Check your email inbox (and spam folder), or
+                            contact support.
+                        </p>
+                    </div>
+                )}
+            </form>
+
+            {/* Error banner */}
+            {isError && (
+                <div className="mx-6 sm:mx-10 mt-6 flex items-start gap-3 px-4 py-3 rounded-xl bg-red-50 border border-red-100">
+                    <IoAlertCircleOutline className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-red-900">
+                            We couldn&apos;t find that voucher.
+                        </p>
+                        <p className="text-xs text-red-700 mt-0.5 leading-relaxed">{errorMessage}</p>
+                    </div>
+                </div>
+            )}
+
+            {/* Fetched voucher success */}
+            {voucher && !isLoading && (
+                <div className="px-6 sm:px-10 pt-8 pb-10 mt-6 border-t border-gray-100 space-y-8">
+                    <VoucherMetric
+                        count={downloadableCount}
+                        label={downloadableCount === 1 ? 'certificate' : 'certificates'}
+                        statusText={
+                            paidCount < voucher.studentCount
+                                ? `${voucher.studentCount - paidCount} still being prepared`
+                                : 'Ready to download'
+                        }
+                        statusColor={paidCount < voucher.studentCount ? 'bg-amber-500' : 'bg-green-500'}
+                        amount={voucher.amountPaid}
+                    />
+
+                    <div className="border-t border-gray-100 pt-6">
+                        <VoucherDetails voucher={voucher} />
+                    </div>
+
+                    {downloadableCount > 0 && (
+                        <StudentList voucher={voucher} />
+                    )}
+
+                    {paidCount === 0 && voucher.studentCount > 0 && (
+                        <div className="px-4 py-4 rounded-xl bg-amber-50 border border-amber-100 text-sm text-amber-900 flex items-start gap-3">
+                            <IoAlertCircleOutline className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+                            <div className="flex-1 min-w-0">
+                                <p className="font-semibold">Your certificates are being prepared.</p>
+                                <p className="text-xs mt-1 text-amber-800 leading-relaxed">
+                                    This voucher covers {voucher.studentCount}{' '}
+                                    {voucher.studentCount === 1 ? 'student' : 'students'}, but
+                                    the certificates aren&apos;t quite ready yet &mdash; the system
+                                    usually finishes within a few seconds.
+                                </p>
+                                <button
+                                    type="button"
+                                    onClick={() => trigger(voucher.voucherReference)}
+                                    className="mt-2.5 inline-flex items-center gap-1.5 text-xs font-medium text-amber-900 hover:text-amber-950 cursor-pointer"
+                                >
+                                    <IoRefresh className="w-3.5 h-3.5" />
+                                    <span>Check again</span>
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    {downloadableCount > 0 && (
+                        <div className="border-t border-gray-100 pt-6">
+                            <DownloadSection count={downloadableCount} voucher={voucher} />
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    )
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/bulkApiAdapter.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/bulkApiAdapter.ts
@@ -1,0 +1,42 @@
+/**
+ * Adapters that map the minimal backend contract to the wider `BulkStudent`
+ * type used by the table UI.
+ *
+ * The `/ubeat/students/by-school` and `/bece/students/by-school` endpoints
+ * only return `{ _id, name, isPaid }` — the table UI may want richer info
+ * (e.g. school name in the modal), so we fold in the request context here.
+ */
+
+import type { BulkStudentListItem } from '@/app/result-checking/store/api/studentApi'
+import type { BulkStudent } from './types'
+
+interface MapContext {
+    schoolId: string
+    schoolName: string
+    lga: string
+    examYear: string | number
+}
+
+/**
+ * Convert one row of the API response into the `BulkStudent` shape used
+ * by the table. Fields not in the contract (examNo, class, gender…) are
+ * intentionally left undefined — the row component renders `—` in that case.
+ */
+export function mapBulkStudentListItem(
+    item: BulkStudentListItem,
+    ctx: MapContext,
+): BulkStudent {
+    const isPaid = Boolean(item.isPaid)
+    const yearNum = typeof ctx.examYear === 'string' ? Number(ctx.examYear) : ctx.examYear
+
+    return {
+        _id: item._id,
+        studentName: item.name,
+        paymentStatus: isPaid ? 'paid' : 'unpaid',
+        certificateReady: isPaid,
+        schoolId: ctx.schoolId,
+        schoolName: ctx.schoolName,
+        lga: ctx.lga,
+        examYear: Number.isFinite(yearNum) ? yearNum : undefined,
+    }
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/examConfig.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/examConfig.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-exam configuration for the Bulk Downloads pages.
+ *
+ * Both `/bulk-downloads/bece` and `/bulk-downloads/ubeat` share the exact same
+ * UI (`BulkPageContent`); only the labels, pricing, certificate name and
+ * (future) mutation hooks differ. This file is the single source of truth for
+ * those differences so adding a third exam later is a one-line change.
+ */
+
+import type { BulkExamType } from './types'
+
+export interface BulkExamConfig {
+    examType: BulkExamType
+    /** Short label used in headings & buttons — e.g. "BECE". */
+    shortName: string
+    /** Long, accessible label used in <abbr title="..."> tooltips. */
+    fullName: string
+    /** Page-level subtitle shown beside the logo. */
+    subtitle: string
+    /** Naira amount per certificate. Displayed and used for total calculation. */
+    pricePerStudent: number
+    /** What the certificate is called on this exam (used in modals + ZIP name). */
+    certificateLabel: string
+    /** Prefix for the downloaded ZIP file. */
+    zipFilenamePrefix: string
+    /** Route to the public single-student page (used as fallback link). */
+    singleStudentRoute: string
+    /** Route this bulk-downloads variant lives at. */
+    bulkRoute: string
+}
+
+export const BULK_EXAM_CONFIGS: Record<BulkExamType, BulkExamConfig> = {
+    bece: {
+        examType: 'bece',
+        shortName: 'BECE',
+        fullName: 'Basic Education Certificate Examination',
+        subtitle: 'Bulk Certificate Downloads · Agent View',
+        pricePerStudent: 1000,
+        certificateLabel: 'BECE Certificate',
+        zipFilenamePrefix: 'BECE_Certificates',
+        singleStudentRoute: '/result-checking/bece',
+        bulkRoute: '/result-checking/bece/bulk-downloads',
+    },
+    ubeat: {
+        examType: 'ubeat',
+        shortName: 'UBEAT',
+        fullName: 'Universal Basic Education Assessment Test',
+        subtitle: 'Bulk FSLC Downloads · Agent View',
+        pricePerStudent: 1000,
+        certificateLabel: 'FSLC (UBEAT)',
+        zipFilenamePrefix: 'UBEAT_FSLC_Certificates',
+        singleStudentRoute: '/result-checking/ubeat',
+        bulkRoute: '/result-checking/ubeat/bulk-downloads',
+    },
+}
+
+/** Convenience: format a Naira amount the same way everywhere. */
+export const formatNaira = (amount: number): string =>
+    new Intl.NumberFormat('en-NG', {
+        style: 'currency',
+        currency: 'NGN',
+        minimumFractionDigits: 0,
+    }).format(amount)

--- a/src/app/result-checking/ubeat/bulk-downloads/components/format.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/format.ts
@@ -1,0 +1,21 @@
+/**
+ * Small formatting helpers used across the bulk-downloads UI.
+ */
+
+/**
+ * Convert a string to Title Case while keeping common name punctuation
+ * (spaces, hyphens, periods) intact.
+ *
+ *   "ABASURUM FLORA CHIJINDU"     → "Abasurum Flora Chijindu"
+ *   "NNAH-OFORJI IFECHUKWU"      → "Nnah-Oforji Ifechukwu"
+ *   "CHIDIEBUBE O."              → "Chidiebube O."
+ *   "AKWILAM NMESOMA SARAH"      → "Akwilam Nmesoma Sarah"
+ *
+ * Non-letter characters (periods, commas, digits) are preserved as-is.
+ */
+export function toTitleCase(value: string): string {
+    if (!value) return value
+    return value
+        .toLowerCase()
+        .replace(/(^|[\s-])\p{L}/gu, match => match.toUpperCase())
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/mockData.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/mockData.ts
@@ -1,0 +1,19 @@
+/**
+ * Constants for the Bulk Downloads search form.
+ *
+ * Both the available years and the LGA-→-school cascade are now pulled
+ * live via RTK Query:
+ *   - Years  → `useGetAvailableYearsQuery({ examType })`
+ *   - Schools → `useGetSchoolNamesQuery({ lga })`
+ *
+ * Only the static list of LGAs (derived from the shared `LgaEnum`) lives
+ * here, since the enum is the single source of truth across the portal.
+ */
+
+import { LgaEnum } from '@/app/portal/dashboard/[schoolCode]/types'
+
+/** LGA options (mirrors `LgaEnum` from the portal types). */
+export const LGA_OPTIONS = Object.values(LgaEnum).map(lga => ({
+    value: lga,
+    label: lga,
+}))

--- a/src/app/result-checking/ubeat/bulk-downloads/components/types.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared types for the Bulk Result Downloads (Agent) flow.
+ *
+ * The shape of `BulkStudent` is intentionally a superset of the backend
+ * contract (`{ _id, name, isPaid }` — see `BulkStudentListItem` in
+ * `studentApi.ts`). Richer fields are marked optional so the same type
+ * works for both the live API response and a future detailed view fetched
+ * via the per-student `getUBEATResult` / `getBECEResult` endpoints.
+ */
+
+export type BulkExamType = 'bece' | 'ubeat'
+
+/** Payment state of a single student in the bulk list. */
+export type BulkPaymentStatus = 'paid' | 'unpaid' | 'pending'
+
+/** A single student row in the bulk-downloads table. */
+export interface BulkStudent {
+    /** Mongo ObjectId — used as the stable React key & for payment mutations. */
+    _id: string
+    /** Full legal name. Sourced from the API's `name` field. */
+    studentName: string
+    /** Tri-state payment status derived from the API's `isPaid: boolean`. */
+    paymentStatus: BulkPaymentStatus
+    /** Convenience mirror of `paymentStatus === 'paid'`. */
+    certificateReady?: boolean
+
+    // ── Optional context fields (not in the bulk-list contract) ──────────
+    /** XX/000/000 — available only after fetching the detailed result. */
+    examNo?: string
+    /** Exam-specific class label (e.g. "JSS3", "Primary 6"). */
+    studentClass?: string
+    gender?: 'male' | 'female' | string
+    examYear?: number
+    /** Display label of the school (already resolved server-side). */
+    schoolName?: string
+    /** Mongo id of the school — useful for sub-queries. */
+    schoolId?: string
+    /** Imo State LGA name (matches LgaEnum). */
+    lga?: string
+}
+
+/** Search filters captured from `BulkSearchForm`. */
+export interface BulkSearchFilters {
+    examYear: string
+    lga: string
+    /** Selected `{ id, name }` so we can display the label without re-querying. */
+    school: { id: string; name: string }
+}
+
+/** Tri-state status filter for the results toolbar chips. */
+export type BulkStatusFilter = 'all' | 'paid' | 'unpaid'
+
+/** Paginated wrapper used internally by the table view. */
+export interface BulkStudentsResponse {
+    data: BulkStudent[]
+    currentPage: number
+    totalPages: number
+    totalItems: number
+}
+
+/**
+ * Local UI state for the bulk action bar.
+ * Calculated from `selectedIds` against the current page of `BulkStudent[]`.
+ */
+export interface BulkSelectionSummary {
+    selectedCount: number
+    payableCount: number      // selected & unpaid
+    downloadableCount: number // selected & paid (cert ready)
+    totalAmount: number       // payableCount * pricePerStudent
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/components/voucherStorage.ts
+++ b/src/app/result-checking/ubeat/bulk-downloads/components/voucherStorage.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import type { VoucherResponse } from '@/app/result-checking/store/api/studentApi'
+
+const STORAGE_KEY_PREFIX = 'bulk-voucher-'
+
+let cachedKey: Promise<CryptoKey> | null = null
+
+async function getKey(): Promise<CryptoKey> {
+    if (cachedKey) return cachedKey
+    cachedKey = (async () => {
+        const salt = new TextEncoder().encode('moe-voucher-v1')
+        const keyMaterial = await crypto.subtle.importKey(
+            'raw',
+            new TextEncoder().encode('moe-bulk-download-key-2026'),
+            'PBKDF2',
+            false,
+            ['deriveKey'],
+        )
+        return crypto.subtle.deriveKey(
+            { name: 'PBKDF2', salt, iterations: 100_000, hash: 'SHA-256' },
+            keyMaterial,
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+        )
+    })()
+    return cachedKey
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+    let binary = ''
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+    return btoa(binary)
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+    const binary = atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+}
+
+export async function saveVoucherToStorage(examType: string, voucher: VoucherResponse): Promise<void> {
+    try {
+        const key = await getKey()
+        const iv = crypto.getRandomValues(new Uint8Array(12))
+        const data = new TextEncoder().encode(JSON.stringify(voucher))
+        const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data)
+        const combined = new Uint8Array(iv.length + ciphertext.byteLength)
+        combined.set(iv)
+        combined.set(new Uint8Array(ciphertext), iv.length)
+        localStorage.setItem(STORAGE_KEY_PREFIX + examType, uint8ArrayToBase64(combined))
+    } catch (e) {
+        console.error('Failed to save voucher', e)
+    }
+}
+
+export async function loadVoucherFromStorage(examType: string): Promise<VoucherResponse | null> {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + examType)
+        if (!raw) return null
+        const key = await getKey()
+        const combined = base64ToUint8Array(raw)
+        const iv = combined.slice(0, 12)
+        const ciphertext = combined.slice(12)
+        const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+        return JSON.parse(new TextDecoder().decode(decrypted)) as VoucherResponse
+    } catch (e) {
+        console.error('Failed to load voucher', e)
+        localStorage.removeItem(STORAGE_KEY_PREFIX + examType)
+        return null
+    }
+}
+
+export function hasVoucherInStorage(examType: string): boolean {
+    if (typeof window === 'undefined') return false
+    return !!localStorage.getItem(STORAGE_KEY_PREFIX + examType)
+}
+
+export function clearVoucherFromStorage(examType: string): void {
+    localStorage.removeItem(STORAGE_KEY_PREFIX + examType)
+}

--- a/src/app/result-checking/ubeat/bulk-downloads/page.tsx
+++ b/src/app/result-checking/ubeat/bulk-downloads/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { studentPortalMetadata } from '@/lib/metadata'
+import BulkPageContent from './components/BulkPageContent'
+import { BULK_EXAM_CONFIGS } from './components/examConfig'
+
+export const metadata = studentPortalMetadata.bulkDownloadsUBEAT
+
+function BulkUBEATFallback() {
+    return (
+        <div className="min-h-screen bg-[#F3F3F3] flex items-center justify-center">
+            <div className="animate-spin rounded-full h-10 w-10 border-2 border-green-600 border-t-transparent" />
+        </div>
+    )
+}
+
+export default function BulkUBEATDownloadsScreen() {
+    return (
+        <Suspense fallback={<BulkUBEATFallback />}>
+            <BulkPageContent config={BULK_EXAM_CONFIGS.ubeat} />
+        </Suspense>
+    )
+}

--- a/src/app/result-checking/ubeat/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/components/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { IoPersonCircle, IoLockClosed, IoCalendarOutline, IoSwapHorizontal, IoChevronForward, IoClose, IoTrashOutline, IoChevronDown, IoChevronUp } from 'react-icons/io5'
+import { IoPersonCircle, IoLockClosed, IoCalendarOutline, IoSwapHorizontal, IoChevronForward, IoClose, IoTrashOutline, IoChevronDown, IoChevronUp, IoDownloadOutline } from 'react-icons/io5'
 import toast from 'react-hot-toast'
 import Lottie from 'lottie-react'
 import animationData from '../../assets/students.json'
@@ -826,6 +826,20 @@ export default function UBEATLogin() {
                                             Don&apos;t know your exam number? Click here
                                         </button>
                                     </div>
+
+                                    <div className="flex items-center gap-3 pt-1">
+                                        <div className="flex-1 h-px bg-gray-100" />
+                                        <span className="text-[10px] uppercase tracking-wider text-gray-400">or</span>
+                                        <div className="flex-1 h-px bg-gray-100" />
+                                    </div>
+
+                                    <Link
+                                        href="/result-checking/ubeat/bulk-downloads"
+                                        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-200 hover:border-green-300 hover:bg-green-50 hover:text-green-700 transition-all duration-150 cursor-pointer"
+                                    >
+                                        <IoDownloadOutline className="w-4 h-4" />
+                                        Agent? Bulk-download a whole school cohort
+                                    </Link>
                                 </form>
                             )) : matchedStudents ? (
                                 /* ── Student Selection ── */

--- a/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
+++ b/src/app/result-checking/ubeat/dashboard/components/PageContent.tsx
@@ -25,13 +25,13 @@ const EXAM_NO_REGEX_02 = /^[a-zA-Z]{2}\/\d{1,4}\/\d{4}\/\d{1,4}$/
 const EXAM_NO_REGEX_03 = /^[a-zA-Z]{2}\/[a-zA-Z]{1,2}\/\d{1,4}\/\d{1,4}$/
 
 export default function UBEATDashboard() {
-    const isMobile = useMedia('(max-width: 1000px)')
+    const isMobile = useMedia('(max-width: 1000px)');
 
-    const router = useRouter()
-    const searchParams = useSearchParams()
-    const certificateRef = useRef<HTMLDivElement>(null)
-    const [isDownloading, setIsDownloading] = useState(false)
-    const [examId, setExamId] = useState<string | null>(null)
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const certificateRef = useRef<HTMLDivElement>(null);
+    const [isDownloading, setIsDownloading] = useState(false);
+    const [examId, setExamId] = useState<string | null>(null);
 
     // Check for payment success from URL params
     useEffect(() => {
@@ -472,6 +472,22 @@ export default function UBEATDashboard() {
                                         </p>
                                     </div>
                                 )}
+                            </div>
+
+                            <div className="mt-6 pt-5 border-t border-gray-100">
+                                <button
+                                    type="button"
+                                    onClick={handleDownload}
+                                    disabled={isDownloading}
+                                    className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold bg-green-600 text-white hover:bg-green-700 active:scale-[0.97] transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {isDownloading ? (
+                                        <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                                    ) : (
+                                        <IoDownload className="w-4 h-4" />
+                                    )}
+                                    <span>{isDownloading ? 'Downloading your FSLC...' : 'Download Your FSLC'}</span>
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -221,6 +221,42 @@ export const studentPortalMetadata = {
         robots: { index: false, follow: false },
     } satisfies Metadata,
 
+    // ── Bulk Downloads (Agent) ────────────────────────────────────────────────
+
+    bulkDownloadsBECE: {
+        title:       'Bulk BECE Downloads',
+        description: 'Search a BECE cohort by year, LGA and school. Process bulk payment and download certificates as a ZIP file.',
+        openGraph: {
+            title:       'Bulk BECE Downloads | Imo State Student Portal',
+            description: 'Pay for a whole school cohort and download BECE certificates in one ZIP file.',
+            url:         `${STUDENT_PORTAL_BASE}/bece/bulk-downloads`,
+            images: [{
+                url:    `${SITE_URL}/images/og/bece.png`,
+                width:  2940,
+                height: 1840,
+                alt:    'Imo State Student Portal — Bulk BECE Downloads',
+            }],
+        },
+        robots: { index: false, follow: false },
+    } satisfies Metadata,
+
+    bulkDownloadsUBEAT: {
+        title:       'Bulk UBEAT Downloads',
+        description: 'Search a UBEAT cohort by year, LGA and school. Process bulk payment and download FSLC certificates as a ZIP file.',
+        openGraph: {
+            title:       'Bulk UBEAT Downloads | Imo State Student Portal',
+            description: 'Pay for a whole school cohort and download UBEAT FSLC certificates in one ZIP file.',
+            url:         `${STUDENT_PORTAL_BASE}/ubeat/bulk-downloads`,
+            images: [{
+                url:    `${SITE_URL}/images/og/ubeat.png`,
+                width:  2940,
+                height: 1840,
+                alt:    'Imo State Student Portal — Bulk UBEAT Downloads',
+            }],
+        },
+        robots: { index: false, follow: false },
+    } satisfies Metadata,
+
     // ── Shared ───────────────────────────────────────────────────────────────
 
     faq: {


### PR DESCRIPTION

## Summary
Adds the bulk-download feature for BECE and UBEAT result-checking portals, allowing agents to pay for and download certificates for entire school cohorts in one ZIP file.

## Changes

### API Layer
- New endpoints: `GET_BULK_STUDENTS_BY_SCHOOL`, `CREATE_BATCH_PAYMENT`, `VERIFY_BATCH_PAYMENT`, `GET_VOUCHER`, `GET_VOUCHER_DOWNLOAD`
- RTK query hooks with response normalization for 4 backend shapes
- Batch payment + verification flow
- Voucher receipt lookup and download

### UI — Bulk Downloads
- School search form (year, LGA, school)
- Paginated student table with server-side status filter (All/Unpaid/Paid)
- Shift-click multi-select with cross-page selection
- Sticky bulk action bar with minimum 20 selection requirement
- Bulk payment modal (Paystack redirect)
- Voucher lookup and download modal
- Voucher storage (localStorage session persistence)

### UX Improvements
- Download certificate button added to student info section on both dashboards (visible on mobile)
- Agent bulk-download link on login pages
- Support widget FAB hidden on mobile for bulk-downloads pages

## Notes
- Branched from `main`
- 7 commits, clean history
